### PR TITLE
Fix CI temporary directory selection

### DIFF
--- a/script/lib/common.bash
+++ b/script/lib/common.bash
@@ -81,7 +81,7 @@ archive_contains() {
 
 make_temp_dir() {
   local prefix="$1"
-  local root="${2:-${TMPDIR:-/tmp}}"
+  local root="${2:-${TMPDIR:-${RUNNER_TEMP:-$DIR/target/tmp}}}"
 
   mkdir -p "$root"
   mktemp -d "${root}/${prefix}.XXXXXX"


### PR DESCRIPTION
## Summary

Use `RUNNER_TEMP` as the fallback generated-file root when CI does not provide `TMPDIR`, with repo-local `target/tmp` as the final fallback. This keeps the shared temporary-directory helper within its cleanup allowlist and unblocks hosted lock validation.
