### PR TITLE
Model Phase 2 native nftables policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@ This repository is the Rust implementation scaffold for Fence, a security agent 
 
 Fence must pass the "airplane test": a normal developer or CI worker should be able to build, test, lint, and package the project without reaching the network after dependencies and toolchains have been explicitly prepared.
 
+The current Phase 2A binary is still non-enforcing: `render-plan` emits a deterministic native `nftables` preview, while `run` fails closed and no code writes readiness or claims protection. Privileged backend evidence and the complete protected lifecycle are later reviewed changes.
+
 ## North-Star Principles
 
 - Hermetic by default: routine build, test, lint, and run workflows must not need the network.
@@ -270,7 +272,7 @@ If any version file changes, update docs and verify the corresponding script beh
 - Merging a version bump to `main` creates the `vX.Y.Z` release through CI.
 - The release workflow is intentionally not manually dispatchable.
 - Do not create or push release tags manually unless the workflow is intentionally being recovered.
-- Phase 1 and the first protected release package should include the Linux x64 binary, checksums, and attestations; the narrow four-command agent CLI does not publish generated completion or man-page artifacts.
+- Phase 2A and the first protected release package should include the Linux x64 binary, checksums, and attestations; the narrow four-command agent CLI does not publish generated completion or man-page artifacts.
 - Release timestamps should come from `SOURCE_DATE_EPOCH`, normally the commit timestamp.
 - The first protected agent release artifact is `x86_64-unknown-linux-gnu` only and is supported only on the tested GitHub-hosted `ubuntu-24.04` x64 target.
 
@@ -283,6 +285,7 @@ If any version file changes, update docs and verify the corresponding script beh
 - Keep example code simple, but avoid teaching unsafe or surprising production patterns.
 - Preserve public API stability unless the task explicitly calls for a breaking Fence change.
 - If changing CLI output or release archive layout, update README examples.
+- Until the protected lifecycle is implemented, `run` must remain fail-closed and no first-party code may emit a ready-state protection assertion.
 
 ## Testing Standards
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@ CI runners against undeclared outbound network access and ordinary
 runner-privilege bypass paths. The intended first enforcement target is a
 GitHub-hosted `ubuntu-24.04` x64 runner executing a native Linux GNU binary.
 
-Fence is not an enforcement agent yet. The current Phase 1 executable strictly
-validates local JSON policy, renders a frozen network-policy plan, and reports
-read-only host support observations. It never applies a network boundary,
-changes privilege state, or reports protection as available.
+Fence is not an enforcement agent yet. The current Phase 2A executable strictly
+validates local JSON policy, renders a frozen policy and deterministic native
+`nftables` ruleset preview, and reports read-only host support observations. It
+never applies a network boundary, changes privilege state, writes readiness, or
+reports protection as available.
 
 Read [docs/v0.md](docs/v0.md) for the normative v0 security boundary,
 interfaces, proof requirements, and implementation roadmap.
@@ -116,10 +117,11 @@ CI additionally runs `script/validate-locks --ci` and
 runners are not fully air-gapped: checkout, action loading, Rust preparation,
 artifact operations, and release publication still require network access.
 
-## Phase 1 CLI
+## Phase 2A CLI
 
-The current binary emits versioned JSON only. `render-plan` is non-mutating,
-and `run` fails closed until the privileged enforcement phases are implemented.
+The current binary emits versioned JSON only. `render-plan` includes the fixed
+`inet fence_v0` ruleset preview, policy hash schema version `2`, and a ruleset
+hash. `run` fails closed until the privileged lifecycle is implemented.
 
 ```console
 script/build
@@ -130,7 +132,8 @@ script/build
 ```
 
 The last command intentionally returns an `enforcement_not_implemented` error
-in Phase 1. Do not use this planner as a runner security control.
+in Phase 2A. Do not use this planner or its ruleset preview as a runner
+security control.
 
 ## Release Baseline
 

--- a/docs/v0.md
+++ b/docs/v0.md
@@ -12,9 +12,10 @@ supported GitHub-hosted Linux runner. This document is the single normative
 design record for the v0 implementation.
 
 Fence is not an enforcement agent today. The repository currently contains a
-hermetic Rust scaffold used to prove dependency, toolchain, testing, coverage,
-and packaging discipline before privileged security behavior is added. A
-packaged scaffold binary is not a security control.
+hermetic Rust CLI that validates and freezes policy, renders a deterministic
+native `nftables` ruleset preview, and reports read-only capability
+observations. It does not apply that preview, write readiness, or establish a
+protection boundary. A packaged planning binary is not a security control.
 
 The first protected release is deliberately narrow:
 
@@ -334,19 +335,30 @@ Command behavior:
 | Command | Purpose | Security-state mutation |
 | --- | --- | --- |
 | `--version` | Identify binary build/version metadata. | None |
-| `check-support` | Inspect host identity read-only and emit that protection is unavailable until enforcement is implemented. | None |
-| `render-plan --config` | Validate JSON, resolve hostnames under bounds, and render the exact frozen plan/report preview. | None |
-| `run --config` | In Phase 1, fail closed without reading configuration; in a later enforcement phase, execute the resident selected-mode lifecycle from root-owned input. | None in Phase 1; yes when implemented |
+| `check-support` | Inspect host identity and native-backend presence read-only, while emitting that protection remains unavailable. | None |
+| `render-plan --config` | Validate JSON, resolve hostnames under bounds, and render the exact frozen policy plus native-ruleset preview. | None |
+| `run --config` | Through Phase 2, fail closed without reading configuration; in the later protected lifecycle, execute selected-mode behavior from root-owned input. | None through Phase 2; yes when implemented |
 
 There are no v0 commands to restore, unlock, disable, flush, update, or
 interactively administer a running agent.
 
-Phase 1 emits versioned JSON only. Successful command results are written to
+Phase 2 emits versioned JSON only. Successful command results are written to
 standard output; structured failures are written to standard error. The
 response envelope contains `schema_version`, `command`, `status`,
 `fence_version`, and exactly one of `data` or `error`. Command-shape failures
 exit `2`; policy, resolution, unsupported, and not-implemented failures exit
 `1`.
+
+In Phase 2A, successful `render-plan` data additionally contains:
+
+- `policy_hash_schema_version: 2` and `policy_hash` for normalized logical
+  policy, including fixed implicit IPv6 control rules;
+- `ruleset_hash` for the exact rendered native-ruleset preview; and
+- `network_enforcement_preview`, including fixed owned objects, hook priority,
+  NFLOG constants, and the generated ruleset text.
+
+These values are planning evidence only. They do not show that any rule has
+been applied or verified.
 
 ### Strict JSON only
 
@@ -393,8 +405,8 @@ Top-level fields:
 | --- | --- |
 | `schema_version` | Required integer; v0 accepts exactly `1`. |
 | `mode` | Required enum: `"block"` or `"audit"`; omission is invalid. |
-| `invocation_id` | Required reportable non-secret slug: 1 through 64 lowercase ASCII letters or digits with internal hyphens only, used for owned names and derived state paths. |
-| `platform_profile` | Phase 1 accepts omission or `"none"` and normalizes both to no profile; named profile identifiers are unavailable until a profile is proved. |
+| `invocation_id` | Required reportable non-secret slug: 1 through 64 lowercase ASCII letters or digits with internal hyphens only, used for reports and derived runtime paths, not kernel object identifiers. |
+| `platform_profile` | Phase 2 accepts omission or `"none"` and normalizes both to no profile; named profile identifiers are unavailable until a profile is proved. |
 | `container_policy` | For `block`, omitted means `"disable"` and `"unsafe_preserve"` is explicit degraded behavior; `audit` cannot request protection-bearing lockdown. |
 | `allowances` | Required array; it may be empty to declare zero user egress. |
 
@@ -444,7 +456,7 @@ user-tunable resource limits:
 | Sampled connection findings retained | 1024 |
 | Serialized local report size | 4 MiB |
 
-Phase 1 uses the host system resolver behind an injectable planning interface,
+Phase 2 uses the host system resolver behind an injectable planning interface,
 allows at most one outstanding hostname query, and applies the per-host
 timeout inside the total DNS budget. If limits are exceeded, Fence fails
 before mutation; it does not truncate effective policy. Findings may be capped
@@ -472,8 +484,8 @@ Requirements:
 - ready/report output is readable by the runner user for local rendering;
 - file creation resists link/path traversal and cross-invocation confusion;
 - runtime contents are not credentials or an unlock capability; and
-- state names used for nftables ownership are derived from bounded validated
-  input, not arbitrary user strings.
+- nftables ownership uses fixed source-defined identifiers and never
+  interpolates the invocation identifier into kernel object names.
 
 ## Effective Policy
 
@@ -506,7 +518,8 @@ effective-policy report. A CIDR entry always names its protocol and port.
 
 An empty user policy is valid. With no enabled platform profile, protected
 block mode allows no user-declared new outbound channel after readiness beyond
-local and established/related behavior required by the firewall model.
+loopback, established/related behavior, and the fixed reported ICMPv6 control
+traffic required by the dual-stack firewall model.
 
 This is useful for offline build phases and makes zero-implicit-egress a
 testable property.
@@ -521,18 +534,24 @@ security state:
 3. Reject any failure, timeout, or address-limit violation.
 4. Normalize addresses by family, deduplicate, and sort deterministically.
 5. Expand hostname entries into concrete effective address rules.
-6. Compute the effective-policy hash as lowercase SHA-256 over compact
-   canonical JSON containing mode, normalized container policy, normalized
-   platform profile, and sorted concrete effective allowance rules.
+6. Compute `policy_hash_schema_version: 2` and the effective-policy hash as
+   lowercase SHA-256 over compact canonical JSON containing that schema
+   version, mode, normalized container policy, normalized platform profile,
+   sorted concrete effective allowance rules, and fixed implicit IPv6 control
+   rules.
 7. In `render-plan`, report the plan and stop without mutation.
-8. In `run`, apply exactly the frozen plan and record it in the report.
+8. In the future protected `run` lifecycle, apply exactly the frozen plan and
+   record it in the report.
 
 After readiness, newly resolved addresses do not expand policy. Fence is not a
 dynamic DNS authorization service.
 
 The policy hash intentionally excludes invocation identifiers, derived paths,
 support observations, timing data, and apply/report status so identical
-effective policy produces the same digest in separate invocations.
+effective policy produces the same digest in separate invocations. Phase 2
+also renders `ruleset_hash`, the lowercase SHA-256 of the exact deterministic
+native-ruleset preview, to distinguish policy identity from backend
+realization.
 
 ### DNS after readiness
 
@@ -574,23 +593,41 @@ weaker backend silently.
 
 ### Owned objects
 
-Each invocation owns deterministic bounded nftables objects derived from its
-validated invocation identifier. The intended logical shape is:
+Fence owns a fixed singleton table. Invocation identifiers remain reportable
+metadata and runtime-path inputs; they are not rendered into kernel object
+identifiers. The Phase 2A logical shape is:
 
 ```text
-table inet fence_<id>
-  chain output
-    hook output priority <reviewed-priority>; policy accept
-  chain forward
-    hook forward priority <reviewed-priority>; policy accept
-  chain classify
-  chain denied
+table inet fence_v0
+  chain fence_output
+    hook output priority 10; policy accept
+  chain fence_forward
+    hook forward priority 10; policy accept
+  chain fence_classify
+  chain fence_violation
 ```
 
-Exact names, priorities, and rule order are implementation constants selected
-and frozen by hosted tests. The important invariants are:
+The owned-object constants are:
+
+| Constant | v0 value |
+| --- | --- |
+| Table family and name | `inet fence_v0` |
+| Hook chains | `fence_output`, `fence_forward` |
+| Regular chains | `fence_classify`, `fence_violation` |
+| Hook priority | numeric `10` |
+| NFLOG group | `4242` |
+| NFLOG prefixes | `fence-v0-block`, `fence-v0-audit` |
+| NFLOG packet-prefix bound | `64` bytes |
+| NFLOG sampling | `100` events/second with burst `100` |
+
+Phase 2 privileged hosted tests must prove the fixed priority on the supported
+image. If that proof fails, Fence fails the phase gate and changes the source
+constant through review; it does not select a priority dynamically. The
+ownership invariants are:
 
 - Fence owns its own table and rules;
+- only one active Fence lifecycle may own the fixed table on a runner;
+- a preexisting `inet fence_v0` table is a hard conflict, never overwritten;
 - no user input is interpolated as arbitrary nft syntax;
 - user-defined allowances become typed generated rules only;
 - output and any relevant forwarded/container path are handled explicitly;
@@ -603,11 +640,13 @@ The effective block plan must include:
 
 1. Necessary loopback behavior.
 2. Established/related return traffic.
-3. Effective TCP and UDP user/profile allowances.
-4. Explicit treatment of traffic paths relevant during container lockdown.
-5. Counted and bounded logged rejection of undeclared new traffic.
-6. No implicit runtime DNS allowance.
-7. Dual-stack state in one verified logical ruleset.
+3. Fixed reported outbound ICMPv6 router solicitation, neighbor solicitation,
+   and neighbor advertisement allowances, requiring hop limit `255`.
+4. Effective TCP and UDP user/profile allowances.
+5. Explicit treatment of traffic paths relevant during container lockdown.
+6. Counted and bounded logged rejection of undeclared new traffic.
+7. No implicit runtime DNS allowance.
+8. Dual-stack state in one verified logical ruleset.
 
 Unauthorized new connections should fail promptly through reject behavior,
 rather than hanging builds through silent drop behavior.
@@ -628,8 +667,13 @@ explicit block policy.
 
 ### Bounded event collection
 
-Fence uses an owned NFLOG path for connection metadata findings. It must not
-depend on scraping unbounded global system logs or capturing payloads.
+Fence uses an owned NFLOG path for connection metadata findings. The selected
+NFLOG interface may transiently deliver at most a `64`-byte packet prefix so
+Fence can parse ordinary IP and TCP/UDP endpoint fields. That bound is not a
+semantic guarantee that the bytes contain headers only: a short packet may
+include early application bytes in memory. Fence must immediately reduce the
+prefix to permitted metadata, discard raw bytes, and never retain or serialize
+packet bytes. It must not scrape unbounded global system logs.
 
 A retained finding may contain:
 
@@ -644,7 +688,7 @@ A retained finding may contain:
 
 A retained finding must not contain:
 
-- packet payload;
+- packet prefix bytes or application payload;
 - environment values;
 - credentials;
 - arbitrary process arguments;
@@ -752,7 +796,8 @@ A bounded JSON report should include:
 - invocation identifier and supported-platform result;
 - selected mode and assurance classification;
 - selected container policy;
-- requested policy, effective frozen policy, and policy hash;
+- requested policy, effective frozen policy, policy-hash schema version,
+  policy hash, and ruleset hash;
 - selected platform profile, if any, including profile identifier and frozen
   contribution;
 - configuration-limit validation state;
@@ -769,7 +814,7 @@ Reports must not include:
 
 - environment dumps;
 - credentials or token-shaped values;
-- packet payload contents;
+- packet-prefix bytes or packet payload contents;
 - source-file contents;
 - arbitrary command-line attribution;
 - privileged restore or update capabilities;
@@ -800,9 +845,10 @@ includes:
 - SHA-pinned GitHub Actions; and
 - script-first local and CI validation entrypoints.
 
-The current Phase 1 Rust CLI implements strict JSON parsing, deterministic
-policy planning, and read-only support reporting only. It proves this
-maintenance surface but does not implement an enforcement boundary.
+The current Phase 2A Rust CLI implements strict JSON parsing, deterministic
+policy and native-ruleset preview generation, typed expected-state
+verification modeling, and read-only support reporting only. It proves this
+modeling surface but does not implement an enforcement boundary.
 
 ### Offline and online boundaries
 
@@ -849,8 +895,8 @@ macOS investigation is expected. During the v0 Linux-only protection phase:
 
 ### Current bootstrap validation
 
-Until the agent is implemented, CI establishes that the public scaffold is
-healthy and hermetic:
+Until the protected lifecycle is implemented, CI establishes that the public
+non-enforcing planner is healthy and hermetic:
 
 - `lint` and ordinary `test` remain portable checks on fixed Ubuntu and macOS
   runners while the first-party Rust surface is portable;
@@ -930,18 +976,23 @@ reports read-only observations and never protection availability; `run` fails
 closed with `enforcement_not_implemented` without reading its configuration
 until the later privileged lifecycle exists.
 
-### Phase 2: Nftables and NFLOG implementation
+### Phase 2: Native network enforcement evidence
 
-Implement:
+Phase 2 is delivered in three reviewable slices without activating public
+`run` or emitting readiness:
 
-- supported-capability probes for native nftables and dual-stack handling;
-- typed generated nftables plans;
-- atomic apply and Fence-owned pre-ready rollback;
-- structured active-state verification;
-- block-mode prompt reject behavior;
-- audit-mode non-blocking observation behavior;
-- bounded NFLOG connection-metadata consumption; and
-- local state/report writes with required ownership and permissions.
+1. Phase 2A freezes singleton nftables ownership, hook/NFLOG constants,
+   versioned policy/ruleset hashes, deterministic ruleset previews, typed
+   expected-state verification models, and read-only backend observation.
+2. Phase 2B implements native `nft` preflight, atomic provisional apply,
+   structured verification, and owned rollback reachable only through
+   privileged namespace-isolated hosted tests.
+3. Phase 2C implements bounded NFLOG finding ingestion and test evidence after
+   explicit dependency and packet-prefix privacy review.
+
+Throughout Phase 2, privileged evidence is classified
+`network_enforcement_test_only`; it is not protected block mode, and
+forwarded-path evidence is not container-containment proof.
 
 ### Phase 3: Resident service and lockdown
 
@@ -992,7 +1043,7 @@ not a prerequisite for proving the agent binary's first local boundary.
 - Hermetic lock validation and existing scaffold test/lint/build/coverage
   scripts still pass.
 
-### Pure Rust tests for Phase 1
+### Pure Rust tests for Phases 1 And 2A
 
 Configuration parsing tests must cover:
 
@@ -1016,6 +1067,11 @@ Policy and reporting tests must cover:
 - derived runtime path constraints;
 - bounded event/report serialization and truncation; and
 - assurance labels for standard block, degraded block, and audit.
+- fixed singleton nftables ownership and deterministic native-ruleset
+  rendering;
+- implicit IPv6 control contribution and policy-hash schema version `2`;
+- ruleset hashing and typed owned-state verification mismatch behavior; and
+- read-only backend observations without public enforcement activation.
 
 ### Privileged hosted tests for Phases 2 Through 4
 
@@ -1029,7 +1085,8 @@ On `ubuntu-24.04` x64, tests must prove:
 - would-be violations are observed but not blocked in audit mode;
 - IPv4 and IPv6 requirements are both met or block fails before ready;
 - no implicit post-ready DNS path exists;
-- bounded NFLOG findings contain metadata but not payloads;
+- bounded NFLOG findings contain approved metadata and never retain or
+  serialize transient packet-prefix bytes or application payloads;
 - passwordless sudo fails in standard protected block mode;
 - Docker/containerd access fails in standard protected block mode;
 - `unsafe_preserve` retains container paths and visibly degrades assurance;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,7 +12,7 @@ use std::path::PathBuf;
 #[derive(Debug, Parser)]
 #[command(
     name = "fence",
-    about = "Fence phase1 policy planning agent",
+    about = "Fence phase2 network-policy modeling agent",
     disable_help_flag = true,
     disable_version_flag = true
 )]
@@ -135,6 +135,16 @@ mod tests {
                 architecture: "x86_64".to_owned(),
             }
         }
+
+        fn network_backend_observation(&self) -> crate::support::NetworkBackendObservation {
+            crate::support::NetworkBackendObservation {
+                required: "native_nftables",
+                nft_binary_expected_path: "/usr/sbin/nft",
+                nft_binary_present: true,
+                nft_version_observed: None,
+                privileged_semantic_proof: "integration_test_required",
+            }
+        }
     }
 
     fn execute_test(args: &[&str]) -> CommandOutput {
@@ -151,7 +161,7 @@ mod tests {
         let support = execute_test(&["fence", "check-support"]);
 
         assert_eq!(version.exit_code, 0);
-        assert!(version.json.contains("\"implementation_phase\":\"phase1\""));
+        assert!(version.json.contains("\"implementation_phase\":\"phase2\""));
         assert_eq!(support.exit_code, 0);
         assert!(support.json.contains("\"protection_available\":false"));
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -142,7 +142,7 @@ pub fn parse_and_normalize(bytes: &[u8]) -> Result<NormalizedConfig, ErrorDetail
     if input.platform_profile.as_deref().unwrap_or("none") != "none" {
         return Err(ErrorDetail::new(
             "invalid_platform_profile",
-            "only the none platform profile is available in phase1",
+            "only the none platform profile is available in phase2",
         )
         .field("platform_profile"));
     }
@@ -150,7 +150,7 @@ pub fn parse_and_normalize(bytes: &[u8]) -> Result<NormalizedConfig, ErrorDetail
     if input.allowances.len() > MAX_ALLOWANCES {
         return Err(ErrorDetail::new(
             "too_many_allowances",
-            "allowances exceeds the fixed phase1 limit",
+            "allowances exceeds the fixed phase2 limit",
         )
         .field("allowances"));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod cli;
 pub mod config;
 pub mod error;
+pub mod nft;
 pub mod output;
 pub mod plan;
 pub mod resolver;
@@ -10,7 +11,7 @@ pub mod support;
 
 use serde::Serialize;
 
-pub const IMPLEMENTATION_PHASE: &str = "phase1";
+pub const IMPLEMENTATION_PHASE: &str = "phase2";
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize)]
 pub struct VersionInfo {
@@ -45,7 +46,7 @@ mod tests {
 
         assert_eq!(info.name, env!("CARGO_PKG_NAME"));
         assert_eq!(info.version, env!("CARGO_PKG_VERSION"));
-        assert_eq!(info.implementation_phase, "phase1");
+        assert_eq!(info.implementation_phase, "phase2");
         assert!(!info.protection_available);
     }
 }

--- a/src/nft.rs
+++ b/src/nft.rs
@@ -1,0 +1,579 @@
+use crate::config::{Mode, Protocol};
+use crate::plan::EffectiveAllowance;
+use serde::{Deserialize, Serialize};
+use std::fmt::Write as _;
+
+pub const NFT_BACKEND: &str = "native_nftables";
+pub const NFT_FAMILY: &str = "inet";
+pub const NFT_TABLE: &str = "fence_v0";
+pub const NFT_OUTPUT_CHAIN: &str = "fence_output";
+pub const NFT_FORWARD_CHAIN: &str = "fence_forward";
+pub const NFT_CLASSIFY_CHAIN: &str = "fence_classify";
+pub const NFT_VIOLATION_CHAIN: &str = "fence_violation";
+pub const NFT_SAMPLED_VIOLATIONS_COUNTER: &str = "fence_sampled_violations";
+pub const NFT_TOTAL_VIOLATIONS_COUNTER: &str = "fence_total_violations";
+pub const NFT_HOOK_PRIORITY: i32 = 10;
+pub const NFLOG_GROUP: u16 = 4242;
+pub const NFLOG_PREFIX_BLOCK: &str = "fence-v0-block";
+pub const NFLOG_PREFIX_AUDIT: &str = "fence-v0-audit";
+pub const NFLOG_PACKET_PREFIX_BYTES: u32 = 64;
+pub const NFLOG_SAMPLE_RATE_PER_SECOND: u32 = 100;
+pub const NFLOG_SAMPLE_BURST: u32 = 100;
+pub const NETWORK_EVIDENCE_STATUS: &str = "network_enforcement_test_only";
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct OwnedTablePreview {
+    pub family: &'static str,
+    pub name: &'static str,
+    pub single_active_invocation: bool,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct HookPreview {
+    pub chain: &'static str,
+    pub hook: &'static str,
+    pub priority: i32,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct ImplicitIpv6Control {
+    pub rule_class: &'static str,
+    pub icmpv6_types: Vec<&'static str>,
+    pub required_hop_limit: u8,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct NflogPreview {
+    pub group: u16,
+    pub prefix: &'static str,
+    pub packet_prefix_bytes: u32,
+    pub sample_rate_per_second: u32,
+    pub sample_burst: u32,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct NetworkEnforcementPreview {
+    pub backend: &'static str,
+    pub activation_status: &'static str,
+    pub owned_table: OwnedTablePreview,
+    pub hooks: Vec<HookPreview>,
+    pub implicit_ipv6_control: ImplicitIpv6Control,
+    pub nflog: NflogPreview,
+    pub ruleset: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct NetworkEvidence {
+    pub status: &'static str,
+    pub mode: Mode,
+    pub policy_hash: String,
+    pub ruleset_hash: String,
+    pub apply_status: &'static str,
+    pub verification_status: &'static str,
+    pub readiness_status: &'static str,
+    pub counters: NetworkEvidenceCounters,
+    pub findings: Vec<String>,
+    pub limitations: Vec<&'static str>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct NetworkEvidenceCounters {
+    pub total_violations: u64,
+    pub sampled_violations: u64,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+pub struct OwnedNftState {
+    pub family: String,
+    pub table: String,
+    pub chains: Vec<OwnedChain>,
+    pub counters: Vec<String>,
+    pub rules: Vec<OwnedRule>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(tag = "chain_kind", rename_all = "snake_case")]
+pub enum OwnedChain {
+    Base {
+        name: String,
+        chain_type: String,
+        hook: String,
+        priority: i32,
+        policy: String,
+    },
+    Regular {
+        name: String,
+    },
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(tag = "rule_class", rename_all = "snake_case")]
+pub enum OwnedRule {
+    Loopback {
+        chain: String,
+    },
+    EstablishedRelated {
+        chain: String,
+    },
+    ImplicitIpv6Control {
+        chain: String,
+        icmpv6_types: Vec<String>,
+        required_hop_limit: u8,
+    },
+    ClassifyDispatch {
+        chain: String,
+    },
+    Allowance {
+        chain: String,
+        address_family: String,
+        destination: String,
+        protocol: String,
+        port: u16,
+    },
+    ViolationDispatch {
+        chain: String,
+    },
+    SampledViolation {
+        chain: String,
+        nflog_group: u16,
+        prefix: String,
+        packet_prefix_bytes: u32,
+        sample_rate_per_second: u32,
+        sample_burst: u32,
+    },
+    TerminalViolation {
+        chain: String,
+        verdict: String,
+    },
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct VerificationFailure {
+    pub code: &'static str,
+    pub message: &'static str,
+}
+
+pub fn implicit_ipv6_control() -> ImplicitIpv6Control {
+    ImplicitIpv6Control {
+        rule_class: "implicit_ipv6_control",
+        icmpv6_types: vec![
+            "router_solicitation",
+            "neighbor_solicitation",
+            "neighbor_advertisement",
+        ],
+        required_hop_limit: 255,
+    }
+}
+
+pub fn build_preview(mode: Mode, allowances: &[EffectiveAllowance]) -> NetworkEnforcementPreview {
+    NetworkEnforcementPreview {
+        backend: NFT_BACKEND,
+        activation_status: "not_applied",
+        owned_table: OwnedTablePreview {
+            family: NFT_FAMILY,
+            name: NFT_TABLE,
+            single_active_invocation: true,
+        },
+        hooks: hook_preview(),
+        implicit_ipv6_control: implicit_ipv6_control(),
+        nflog: NflogPreview {
+            group: NFLOG_GROUP,
+            prefix: nflog_prefix(mode),
+            packet_prefix_bytes: NFLOG_PACKET_PREFIX_BYTES,
+            sample_rate_per_second: NFLOG_SAMPLE_RATE_PER_SECOND,
+            sample_burst: NFLOG_SAMPLE_BURST,
+        },
+        ruleset: render_ruleset(mode, allowances),
+    }
+}
+
+pub fn unapplied_test_evidence_model(
+    mode: Mode,
+    policy_hash: String,
+    ruleset_hash: String,
+) -> NetworkEvidence {
+    NetworkEvidence {
+        status: NETWORK_EVIDENCE_STATUS,
+        mode,
+        policy_hash,
+        ruleset_hash,
+        apply_status: "not_applied",
+        verification_status: "not_verified",
+        readiness_status: "not_emitted",
+        counters: NetworkEvidenceCounters {
+            total_violations: 0,
+            sampled_violations: 0,
+        },
+        findings: Vec::new(),
+        limitations: vec![
+            "network_test_evidence_only_no_containment",
+            "readiness_not_available",
+        ],
+    }
+}
+
+pub fn expected_owned_state(mode: Mode, allowances: &[EffectiveAllowance]) -> OwnedNftState {
+    OwnedNftState {
+        family: NFT_FAMILY.to_owned(),
+        table: NFT_TABLE.to_owned(),
+        chains: vec![
+            OwnedChain::Base {
+                name: NFT_OUTPUT_CHAIN.to_owned(),
+                chain_type: "filter".to_owned(),
+                hook: "output".to_owned(),
+                priority: NFT_HOOK_PRIORITY,
+                policy: "accept".to_owned(),
+            },
+            OwnedChain::Base {
+                name: NFT_FORWARD_CHAIN.to_owned(),
+                chain_type: "filter".to_owned(),
+                hook: "forward".to_owned(),
+                priority: NFT_HOOK_PRIORITY,
+                policy: "accept".to_owned(),
+            },
+            OwnedChain::Regular {
+                name: NFT_CLASSIFY_CHAIN.to_owned(),
+            },
+            OwnedChain::Regular {
+                name: NFT_VIOLATION_CHAIN.to_owned(),
+            },
+        ],
+        counters: vec![
+            NFT_SAMPLED_VIOLATIONS_COUNTER.to_owned(),
+            NFT_TOTAL_VIOLATIONS_COUNTER.to_owned(),
+        ],
+        rules: build_rules(mode, allowances),
+    }
+}
+
+pub fn verify_owned_state(
+    expected: &OwnedNftState,
+    observed: &OwnedNftState,
+) -> Result<(), VerificationFailure> {
+    if expected == observed {
+        Ok(())
+    } else {
+        Err(VerificationFailure {
+            code: "owned_nft_state_mismatch",
+            message: "active owned nftables state does not match the generated plan",
+        })
+    }
+}
+
+pub fn render_ruleset(mode: Mode, allowances: &[EffectiveAllowance]) -> String {
+    let mut program = String::new();
+    writeln!(&mut program, "create table {NFT_FAMILY} {NFT_TABLE}").unwrap();
+    writeln!(
+        &mut program,
+        "add counter {NFT_FAMILY} {NFT_TABLE} {NFT_SAMPLED_VIOLATIONS_COUNTER}"
+    )
+    .unwrap();
+    writeln!(
+        &mut program,
+        "add counter {NFT_FAMILY} {NFT_TABLE} {NFT_TOTAL_VIOLATIONS_COUNTER}"
+    )
+    .unwrap();
+    writeln!(
+        &mut program,
+        "add chain {NFT_FAMILY} {NFT_TABLE} {NFT_CLASSIFY_CHAIN}"
+    )
+    .unwrap();
+    writeln!(
+        &mut program,
+        "add chain {NFT_FAMILY} {NFT_TABLE} {NFT_VIOLATION_CHAIN}"
+    )
+    .unwrap();
+    writeln!(
+        &mut program,
+        "add chain {NFT_FAMILY} {NFT_TABLE} {NFT_OUTPUT_CHAIN} {{ type filter hook output priority {NFT_HOOK_PRIORITY}; policy accept; }}"
+    )
+    .unwrap();
+    writeln!(
+        &mut program,
+        "add chain {NFT_FAMILY} {NFT_TABLE} {NFT_FORWARD_CHAIN} {{ type filter hook forward priority {NFT_HOOK_PRIORITY}; policy accept; }}"
+    )
+    .unwrap();
+    for rule in build_rules(mode, allowances) {
+        render_rule(&mut program, &rule);
+    }
+    program
+}
+
+fn hook_preview() -> Vec<HookPreview> {
+    vec![
+        HookPreview {
+            chain: NFT_OUTPUT_CHAIN,
+            hook: "output",
+            priority: NFT_HOOK_PRIORITY,
+        },
+        HookPreview {
+            chain: NFT_FORWARD_CHAIN,
+            hook: "forward",
+            priority: NFT_HOOK_PRIORITY,
+        },
+    ]
+}
+
+fn nflog_prefix(mode: Mode) -> &'static str {
+    match mode {
+        Mode::Block => NFLOG_PREFIX_BLOCK,
+        Mode::Audit => NFLOG_PREFIX_AUDIT,
+    }
+}
+
+fn build_rules(mode: Mode, allowances: &[EffectiveAllowance]) -> Vec<OwnedRule> {
+    let control = implicit_ipv6_control();
+    let mut rules = vec![
+        OwnedRule::Loopback {
+            chain: NFT_OUTPUT_CHAIN.to_owned(),
+        },
+        OwnedRule::EstablishedRelated {
+            chain: NFT_OUTPUT_CHAIN.to_owned(),
+        },
+        OwnedRule::ImplicitIpv6Control {
+            chain: NFT_OUTPUT_CHAIN.to_owned(),
+            icmpv6_types: control
+                .icmpv6_types
+                .into_iter()
+                .map(str::to_owned)
+                .collect(),
+            required_hop_limit: control.required_hop_limit,
+        },
+        OwnedRule::ClassifyDispatch {
+            chain: NFT_OUTPUT_CHAIN.to_owned(),
+        },
+        OwnedRule::EstablishedRelated {
+            chain: NFT_FORWARD_CHAIN.to_owned(),
+        },
+        OwnedRule::ClassifyDispatch {
+            chain: NFT_FORWARD_CHAIN.to_owned(),
+        },
+    ];
+    rules.extend(allowances.iter().map(|allowance| OwnedRule::Allowance {
+        chain: NFT_CLASSIFY_CHAIN.to_owned(),
+        address_family: if allowance.destination.contains(':') {
+            "ip6".to_owned()
+        } else {
+            "ip".to_owned()
+        },
+        destination: allowance.destination.clone(),
+        protocol: match allowance.protocol {
+            Protocol::Tcp => "tcp".to_owned(),
+            Protocol::Udp => "udp".to_owned(),
+        },
+        port: allowance.port,
+    }));
+    rules.push(OwnedRule::ViolationDispatch {
+        chain: NFT_CLASSIFY_CHAIN.to_owned(),
+    });
+    rules.push(OwnedRule::SampledViolation {
+        chain: NFT_VIOLATION_CHAIN.to_owned(),
+        nflog_group: NFLOG_GROUP,
+        prefix: nflog_prefix(mode).to_owned(),
+        packet_prefix_bytes: NFLOG_PACKET_PREFIX_BYTES,
+        sample_rate_per_second: NFLOG_SAMPLE_RATE_PER_SECOND,
+        sample_burst: NFLOG_SAMPLE_BURST,
+    });
+    rules.push(OwnedRule::TerminalViolation {
+        chain: NFT_VIOLATION_CHAIN.to_owned(),
+        verdict: match mode {
+            Mode::Block => "reject".to_owned(),
+            Mode::Audit => "accept".to_owned(),
+        },
+    });
+    rules
+}
+
+fn render_rule(program: &mut String, rule: &OwnedRule) {
+    match rule {
+        OwnedRule::Loopback { chain } => {
+            writeln!(
+                program,
+                "add rule {NFT_FAMILY} {NFT_TABLE} {chain} oifname \"lo\" accept comment \"fence:loopback\""
+            )
+            .unwrap();
+        }
+        OwnedRule::EstablishedRelated { chain } => {
+            writeln!(
+                program,
+                "add rule {NFT_FAMILY} {NFT_TABLE} {chain} ct state established,related accept comment \"fence:established\""
+            )
+            .unwrap();
+        }
+        OwnedRule::ImplicitIpv6Control {
+            chain,
+            required_hop_limit,
+            ..
+        } => {
+            writeln!(
+                program,
+                "add rule {NFT_FAMILY} {NFT_TABLE} {chain} meta nfproto ipv6 ip6 hoplimit {required_hop_limit} icmpv6 type {{ nd-router-solicit, nd-neighbor-solicit, nd-neighbor-advert }} accept comment \"fence:implicit_ipv6_control\""
+            )
+            .unwrap();
+        }
+        OwnedRule::ClassifyDispatch { chain } => {
+            writeln!(
+                program,
+                "add rule {NFT_FAMILY} {NFT_TABLE} {chain} jump {NFT_CLASSIFY_CHAIN} comment \"fence:classify\""
+            )
+            .unwrap();
+        }
+        OwnedRule::Allowance {
+            chain,
+            address_family,
+            destination,
+            protocol,
+            port,
+        } => {
+            writeln!(
+                program,
+                "add rule {NFT_FAMILY} {NFT_TABLE} {chain} {address_family} daddr {destination} {protocol} dport {port} accept comment \"fence:allowance\""
+            )
+            .unwrap();
+        }
+        OwnedRule::ViolationDispatch { chain } => {
+            writeln!(
+                program,
+                "add rule {NFT_FAMILY} {NFT_TABLE} {chain} jump {NFT_VIOLATION_CHAIN} comment \"fence:violation\""
+            )
+            .unwrap();
+        }
+        OwnedRule::SampledViolation {
+            chain,
+            nflog_group,
+            prefix,
+            packet_prefix_bytes,
+            sample_rate_per_second,
+            sample_burst,
+        } => {
+            writeln!(
+                program,
+                "add rule {NFT_FAMILY} {NFT_TABLE} {chain} limit rate {sample_rate_per_second}/second burst {sample_burst} packets counter name {NFT_SAMPLED_VIOLATIONS_COUNTER} log group {nflog_group} prefix \"{prefix}\" queue-threshold 1 snaplen {packet_prefix_bytes} comment \"fence:sample_violation\""
+            )
+            .unwrap();
+        }
+        OwnedRule::TerminalViolation { chain, verdict } => {
+            writeln!(
+                program,
+                "add rule {NFT_FAMILY} {NFT_TABLE} {chain} counter name {NFT_TOTAL_VIOLATIONS_COUNTER} {verdict} comment \"fence:{verdict}_violation\""
+            )
+            .unwrap();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::DestinationType;
+
+    fn allowances() -> Vec<EffectiveAllowance> {
+        vec![
+            EffectiveAllowance {
+                destination_type: DestinationType::Ip,
+                destination: "192.0.2.10".to_owned(),
+                protocol: Protocol::Tcp,
+                port: 443,
+            },
+            EffectiveAllowance {
+                destination_type: DestinationType::Cidr,
+                destination: "2001:db8::/64".to_owned(),
+                protocol: Protocol::Udp,
+                port: 53,
+            },
+        ]
+    }
+
+    #[test]
+    fn renders_fixed_block_ruleset_with_allowances_and_implicit_control() {
+        let preview = build_preview(Mode::Block, &allowances());
+
+        assert_eq!(preview.owned_table.name, NFT_TABLE);
+        assert!(preview.owned_table.single_active_invocation);
+        assert_eq!(preview.hooks[0].priority, NFT_HOOK_PRIORITY);
+        assert_eq!(
+            preview.implicit_ipv6_control.icmpv6_types,
+            vec![
+                "router_solicitation",
+                "neighbor_solicitation",
+                "neighbor_advertisement"
+            ]
+        );
+        assert!(preview.ruleset.starts_with("create table inet fence_v0\n"));
+        assert!(
+            preview
+                .ruleset
+                .contains("ip daddr 192.0.2.10 tcp dport 443")
+        );
+        assert!(
+            preview
+                .ruleset
+                .contains("ip6 daddr 2001:db8::/64 udp dport 53")
+        );
+        assert!(preview.ruleset.contains("icmpv6 type { nd-router-solicit"));
+        assert!(preview.ruleset.contains("prefix \"fence-v0-block\""));
+        assert!(
+            preview
+                .ruleset
+                .contains("counter name fence_total_violations reject")
+        );
+    }
+
+    #[test]
+    fn audit_uses_non_blocking_terminal_verdict_and_audit_prefix() {
+        let program = render_ruleset(Mode::Audit, &[]);
+
+        assert!(program.contains("prefix \"fence-v0-audit\""));
+        assert!(program.contains("counter name fence_total_violations accept"));
+        assert!(!program.contains("counter name fence_total_violations reject"));
+    }
+
+    #[test]
+    fn expected_state_is_deterministic_and_verification_detects_drift() {
+        let expected = expected_owned_state(Mode::Block, &allowances());
+        let identical = expected_owned_state(Mode::Block, &allowances());
+        let mut drifted = identical.clone();
+        drifted.chains[0] = OwnedChain::Regular {
+            name: NFT_OUTPUT_CHAIN.to_owned(),
+        };
+        let round_trip: OwnedNftState =
+            serde_json::from_slice(&serde_json::to_vec(&expected).unwrap()).unwrap();
+
+        assert!(verify_owned_state(&expected, &identical).is_ok());
+        assert_eq!(round_trip, expected);
+        let failure = verify_owned_state(&expected, &drifted).unwrap_err();
+        assert_eq!(failure.code, "owned_nft_state_mismatch");
+        assert!(failure.message.contains("does not match"));
+        assert!(
+            expected
+                .rules
+                .iter()
+                .any(|rule| matches!(rule, OwnedRule::ViolationDispatch { .. }))
+        );
+        assert_eq!(
+            expected.counters,
+            vec![
+                NFT_SAMPLED_VIOLATIONS_COUNTER.to_owned(),
+                NFT_TOTAL_VIOLATIONS_COUNTER.to_owned()
+            ]
+        );
+    }
+
+    #[test]
+    fn evidence_schema_cannot_claim_readiness_or_containment_before_activation() {
+        let evidence =
+            unapplied_test_evidence_model(Mode::Audit, "policy".to_owned(), "ruleset".to_owned());
+
+        assert_eq!(evidence.status, NETWORK_EVIDENCE_STATUS);
+        assert_eq!(evidence.apply_status, "not_applied");
+        assert_eq!(evidence.verification_status, "not_verified");
+        assert_eq!(evidence.readiness_status, "not_emitted");
+        assert_eq!(evidence.counters.total_violations, 0);
+        assert!(evidence.findings.is_empty());
+        assert!(
+            evidence
+                .limitations
+                .contains(&"network_test_evidence_only_no_containment")
+        );
+    }
+}

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -1,9 +1,11 @@
+use crate::IMPLEMENTATION_PHASE;
 use crate::config::{
     ContainerPolicy, DestinationType, MAX_ALLOWANCES, MAX_EXPANDED_RULES, MAX_FINDINGS,
     MAX_REPORT_BYTES, MAX_RESOLVED_ADDRESSES, Mode, NormalizedAllowance, NormalizedConfig,
     Protocol,
 };
 use crate::error::ErrorDetail;
+use crate::nft::{NetworkEnforcementPreview, build_preview, implicit_ipv6_control};
 use crate::resolver::{Resolution, ResolveError, Resolver};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
@@ -14,6 +16,7 @@ use std::time::Duration;
 
 pub const PER_HOST_DNS_TIMEOUT: Duration = Duration::from_secs(5);
 pub const TOTAL_DNS_BUDGET: Duration = Duration::from_secs(30);
+pub const POLICY_HASH_SCHEMA_VERSION: u32 = 2;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -79,7 +82,10 @@ pub struct PlanData {
     pub effective_policy: Vec<EffectiveAllowance>,
     pub frozen_resolution_results: Vec<ResolutionResult>,
     pub derived_runtime_paths: RuntimePaths,
+    pub policy_hash_schema_version: u32,
     pub policy_hash: String,
+    pub ruleset_hash: String,
+    pub network_enforcement_preview: NetworkEnforcementPreview,
     pub limits: LimitStatus,
     pub findings: FindingState,
     pub application_status: &'static str,
@@ -89,10 +95,12 @@ pub struct PlanData {
 
 #[derive(Serialize)]
 struct PolicyHashInput<'a> {
+    policy_hash_schema_version: u32,
     mode: Mode,
     container_policy: Option<ContainerPolicy>,
     platform_profile: &'a str,
     allowances: &'a [EffectiveAllowance],
+    implicit_ipv6_control: crate::nft::ImplicitIpv6Control,
 }
 
 pub fn build_plan(
@@ -186,6 +194,8 @@ pub fn build_plan(
         })
         .collect();
     let policy_hash = policy_hash(&config, &effective_policy);
+    let network_enforcement_preview = build_preview(config.mode, &effective_policy);
+    let ruleset_hash = sha256_hex(network_enforcement_preview.ruleset.as_bytes());
     let assurance_status = assurance_status(config.mode, config.container_policy);
     let limitations = limitations(assurance_status);
     let invocation_id = config.invocation_id.clone();
@@ -193,7 +203,7 @@ pub fn build_plan(
         expanded_rules_before_deduplication - effective_policy.len();
 
     Ok(PlanData {
-        implementation_phase: "phase1",
+        implementation_phase: IMPLEMENTATION_PHASE,
         configuration_schema_version: config.schema_version,
         selected_mode: config.mode,
         assurance_status,
@@ -204,7 +214,10 @@ pub fn build_plan(
         effective_policy,
         frozen_resolution_results,
         derived_runtime_paths: runtime_paths(&invocation_id),
+        policy_hash_schema_version: POLICY_HASH_SCHEMA_VERSION,
         policy_hash,
+        ruleset_hash,
+        network_enforcement_preview,
         limits: LimitStatus {
             max_user_allowances: MAX_ALLOWANCES,
             declared_user_allowances: config.declared_allowance_count,
@@ -258,7 +271,7 @@ fn assurance_status(mode: Mode, container_policy: Option<ContainerPolicy>) -> As
 }
 
 fn limitations(status: AssuranceStatus) -> Vec<&'static str> {
-    let mut limitations = vec!["phase1_planning_only_no_enforcement"];
+    let mut limitations = vec!["phase2_network_model_only_no_public_enforcement"];
     match status {
         AssuranceStatus::PlannedBlockContainment => {}
         AssuranceStatus::PlannedBlockDegradedContainerAccess => {
@@ -284,12 +297,18 @@ fn runtime_paths(invocation_id: &str) -> RuntimePaths {
 
 fn policy_hash(config: &NormalizedConfig, effective_policy: &[EffectiveAllowance]) -> String {
     let bytes = serde_json::to_vec(&PolicyHashInput {
+        policy_hash_schema_version: POLICY_HASH_SCHEMA_VERSION,
         mode: config.mode,
         container_policy: config.container_policy,
         platform_profile: &config.platform_profile,
         allowances: effective_policy,
+        implicit_ipv6_control: implicit_ipv6_control(),
     })
     .expect("typed policy hashing input must serialize");
+    sha256_hex(&bytes)
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
     let digest = Sha256::digest(bytes);
     let mut hash = String::with_capacity(digest.len() * 2);
     for byte in digest {
@@ -347,7 +366,7 @@ mod tests {
         )
         .unwrap();
         let another = build_plan(
-            parse(&json.replace("one", "two")),
+            parse(r#"{"schema_version":1,"mode":"block","invocation_id":"two","allowances":[{"destination_type":"ip","destination":"192.0.2.2","protocol":"tcp","port":443},{"destination_type":"hostname","destination":"example.com","protocol":"tcp","port":443}]}"#),
             &resolver(vec![resolved(
                 &["2001:db8::1", "192.0.2.2"],
                 Duration::from_secs(1),
@@ -356,10 +375,20 @@ mod tests {
         .unwrap();
 
         assert_eq!(plan.policy_hash, another.policy_hash);
+        assert_eq!(plan.ruleset_hash, another.ruleset_hash);
+        assert_eq!(plan.policy_hash_schema_version, POLICY_HASH_SCHEMA_VERSION);
         assert_eq!(plan.effective_policy.len(), 2);
         assert_eq!(plan.limits.duplicate_effective_rules_collapsed, 1);
         assert_eq!(plan.frozen_resolution_results[0].addresses[0], "192.0.2.2");
         assert_eq!(plan.derived_runtime_paths.directory, "/run/fence/one");
+        assert_eq!(
+            plan.network_enforcement_preview.owned_table.name,
+            crate::nft::NFT_TABLE
+        );
+        assert_eq!(
+            plan.network_enforcement_preview.activation_status,
+            "not_applied"
+        );
     }
 
     #[test]
@@ -392,6 +421,8 @@ mod tests {
             audit.assurance_status,
             AssuranceStatus::AuditObservationOnly
         );
+        assert_ne!(standard.policy_hash, audit.policy_hash);
+        assert_ne!(standard.ruleset_hash, audit.ruleset_hash);
         assert_eq!(degraded.limitations.len(), 2);
         assert_eq!(audit.limitations.len(), 2);
     }

--- a/src/support.rs
+++ b/src/support.rs
@@ -1,4 +1,7 @@
 use serde::Serialize;
+use std::path::Path;
+
+const NFT_BINARY_PATH: &str = "/usr/sbin/nft";
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct HostIdentity {
@@ -8,6 +11,7 @@ pub struct HostIdentity {
 
 pub trait SupportProvider {
     fn host_identity(&self) -> HostIdentity;
+    fn network_backend_observation(&self) -> NetworkBackendObservation;
 }
 
 #[derive(Debug, Default)]
@@ -20,6 +24,25 @@ impl SupportProvider for SystemSupportProvider {
             architecture: std::env::consts::ARCH.to_owned(),
         }
     }
+
+    fn network_backend_observation(&self) -> NetworkBackendObservation {
+        NetworkBackendObservation {
+            required: "native_nftables",
+            nft_binary_expected_path: NFT_BINARY_PATH,
+            nft_binary_present: Path::new(NFT_BINARY_PATH).is_file(),
+            nft_version_observed: None,
+            privileged_semantic_proof: "integration_test_required",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct NetworkBackendObservation {
+    pub required: &'static str,
+    pub nft_binary_expected_path: &'static str,
+    pub nft_binary_present: bool,
+    pub nft_version_observed: Option<String>,
+    pub privileged_semantic_proof: &'static str,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize)]
@@ -31,24 +54,28 @@ pub struct SupportData {
     pub protection_available: bool,
     pub reasons: Vec<&'static str>,
     pub deferred_capability_probes: Vec<&'static str>,
+    pub network_backend: NetworkBackendObservation,
 }
 
 pub fn inspect_support(provider: &dyn SupportProvider) -> SupportData {
     let identity = provider.host_identity();
     SupportData {
-        implementation_phase: "phase1",
+        implementation_phase: "phase2",
         intended_protected_target_match: identity.os == "linux"
             && identity.architecture == "x86_64",
         host_os: identity.os,
         host_architecture: identity.architecture,
         protection_available: false,
-        reasons: vec!["enforcement_not_implemented"],
+        reasons: vec![
+            "public_enforcement_not_activated",
+            "lockdown_not_implemented",
+        ],
         deferred_capability_probes: vec![
-            "native_nftables",
             "transient_systemd_service",
             "sudo_lockdown",
             "container_lockdown",
         ],
+        network_backend: provider.network_backend_observation(),
     }
 }
 
@@ -68,10 +95,20 @@ mod tests {
                 architecture: self.architecture.to_owned(),
             }
         }
+
+        fn network_backend_observation(&self) -> NetworkBackendObservation {
+            NetworkBackendObservation {
+                required: "native_nftables",
+                nft_binary_expected_path: NFT_BINARY_PATH,
+                nft_binary_present: self.os == "linux",
+                nft_version_observed: None,
+                privileged_semantic_proof: "integration_test_required",
+            }
+        }
     }
 
     #[test]
-    fn intended_target_still_reports_no_protection_in_phase1() {
+    fn intended_target_still_reports_no_protection_in_phase2() {
         let data = inspect_support(&FixedProvider {
             os: "linux",
             architecture: "x86_64",
@@ -79,7 +116,14 @@ mod tests {
 
         assert!(data.intended_protected_target_match);
         assert!(!data.protection_available);
-        assert_eq!(data.reasons, vec!["enforcement_not_implemented"]);
+        assert_eq!(
+            data.reasons,
+            vec![
+                "public_enforcement_not_activated",
+                "lockdown_not_implemented"
+            ]
+        );
+        assert!(data.network_backend.nft_binary_present);
     }
 
     #[test]
@@ -91,13 +135,20 @@ mod tests {
 
         assert!(!data.intended_protected_target_match);
         assert!(!data.protection_available);
+        assert!(!data.network_backend.nft_binary_present);
     }
 
     #[test]
     fn system_provider_returns_runtime_identity() {
         let identity = SystemSupportProvider.host_identity();
+        let backend = SystemSupportProvider.network_backend_observation();
 
         assert_eq!(identity.os, std::env::consts::OS);
         assert_eq!(identity.architecture, std::env::consts::ARCH);
+        assert_eq!(backend.nft_binary_expected_path, NFT_BINARY_PATH);
+        assert_eq!(
+            backend.nft_binary_present,
+            Path::new(NFT_BINARY_PATH).is_file()
+        );
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -43,7 +43,7 @@ fn version_is_json_and_does_not_claim_protection() {
 
     assert_eq!(response["command"], "version");
     assert_eq!(response["status"], "success");
-    assert_eq!(response["data"]["implementation_phase"], "phase1");
+    assert_eq!(response["data"]["implementation_phase"], "phase2");
     assert_eq!(response["data"]["protection_available"], false);
 }
 
@@ -55,7 +55,11 @@ fn support_is_read_only_and_not_protective() {
     assert_eq!(response["data"]["protection_available"], false);
     assert_eq!(
         response["data"]["reasons"][0],
-        "enforcement_not_implemented"
+        "public_enforcement_not_activated"
+    );
+    assert_eq!(
+        response["data"]["network_backend"]["nft_binary_expected_path"],
+        "/usr/sbin/nft"
     );
 }
 
@@ -78,6 +82,16 @@ fn renders_deterministic_plan_without_creating_runtime_state() {
     assert_eq!(first, second);
     assert_eq!(first["data"]["application_status"], "not_applied");
     assert_eq!(first["data"]["verification_status"], "not_verified");
+    assert_eq!(first["data"]["policy_hash_schema_version"], 2);
+    assert_eq!(
+        first["data"]["network_enforcement_preview"]["owned_table"]["name"],
+        "fence_v0"
+    );
+    assert_eq!(
+        first["data"]["network_enforcement_preview"]["nflog"]["group"],
+        4242
+    );
+    assert!(first["data"]["ruleset_hash"].as_str().unwrap().len() == 64);
     assert_eq!(
         first["data"]["derived_runtime_paths"]["directory"],
         runtime_path.to_str().unwrap()


### PR DESCRIPTION
## 🧭 Summary

Introduces *Phase 2A* as a non-enforcing network-policy model: `render-plan` now emits a deterministic native `nftables` preview with versioned `policy_hash` and `ruleset_hash` values.

## 🔒 Boundary

Freezes Fence ownership around singleton `inet fence_v0`, fixed hook/NFLOG and implicit IPv6-control constants, typed expected-state verification, and read-only backend observations. **Public enforcement remains unavailable:** `run` still fails closed, no readiness is written, and the binary makes no containment claim.
