### PR TITLE
Prove native nftables backend in privileged tests

### DIFF
--- a/.github/workflows/privileged-integration.yml
+++ b/.github/workflows/privileged-integration.yml
@@ -1,0 +1,43 @@
+name: privileged-integration
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  network-evidence:
+    name: privileged network evidence
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: validate locks
+        run: script/validate-locks --ci
+
+      - name: prepare rust
+        run: script/prepare-rust
+
+      - name: bootstrap
+        run: script/bootstrap
+
+      - name: prove native network behavior in isolated namespaces
+        run: script/test-privileged

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This repository is the Rust implementation scaffold for Fence, a security agent 
 
 Fence must pass the "airplane test": a normal developer or CI worker should be able to build, test, lint, and package the project without reaching the network after dependencies and toolchains have been explicitly prepared.
 
-The current Phase 2B binary is still non-enforcing: `render-plan` emits a deterministic native `nftables` preview, while `run` fails closed and no code writes readiness or claims protection. Native apply/verify/rollback code is reachable only from privileged evidence tests; the complete protected lifecycle is a later reviewed change.
+The current Phase 2B binary is still non-enforcing: `render-plan` emits a deterministic native `nftables` preview, while `run` fails closed and no code writes readiness or claims protection. No first-party runtime path reaches native apply/verify/rollback; the repository exercises it only through privileged evidence tests. The complete protected lifecycle is a later reviewed change.
 
 ## North-Star Principles
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This repository is the Rust implementation scaffold for Fence, a security agent 
 
 Fence must pass the "airplane test": a normal developer or CI worker should be able to build, test, lint, and package the project without reaching the network after dependencies and toolchains have been explicitly prepared.
 
-The current Phase 2A binary is still non-enforcing: `render-plan` emits a deterministic native `nftables` preview, while `run` fails closed and no code writes readiness or claims protection. Privileged backend evidence and the complete protected lifecycle are later reviewed changes.
+The current Phase 2B binary is still non-enforcing: `render-plan` emits a deterministic native `nftables` preview, while `run` fails closed and no code writes readiness or claims protection. Native apply/verify/rollback code is reachable only from privileged evidence tests; the complete protected lifecycle is a later reviewed change.
 
 ## North-Star Principles
 
@@ -117,6 +117,13 @@ All scripts live in `script/` and should use `set -euo pipefail` unless there is
   - Coverage mode enforces 100% line, function, and region coverage for first-party code.
   - Coverage mode must not install tools, use the network, or enable unstable branch coverage.
   - `cargo test` itself does not emit coverage; coverage mode relies on stable Rust source-based coverage instrumentation through `cargo-llvm-cov`.
+  - Rootless coverage intentionally excludes `src/nft_backend.rs`; that Linux privileged backend is proved through deterministic unit tests plus `script/test-privileged` namespace behavior tests on `ubuntu-24.04`.
+
+- `script/test-privileged`
+  - Linux x64-only privileged evidence entrypoint; it must not run on ordinary local or portable test paths.
+  - Verifies `/usr/sbin/nft`, namespace, IPv6, and NFLOG-rule prerequisites before invoking ignored backend tests.
+  - Runs native apply/verify/rollback behavior only inside disposable network namespaces and writes test-only evidence beneath `RUNNER_TEMP`.
+  - Must not invoke the public `run` command, create a readiness file, mutate host firewall rules, or make a protection claim.
 
 - `script/lint`
   - Runs format check, clippy, `cargo verify-project`, and docs.
@@ -256,6 +263,7 @@ If any version file changes, update docs and verify the corresponding script beh
 - Hosted lint/test workflows may remain portable on fixed Ubuntu and macOS labels while their behavior is platform-neutral. Protected integration, package, and release jobs target fixed `ubuntu-24.04` x64 only.
 - Hosted lint/test/build workflows should run `script/validate-locks --ci`, then `script/prepare-rust`, then `script/bootstrap`, then their offline validation command or native package-smoke path.
 - Hosted coverage workflows should run `script/validate-locks --ci`, then `script/prepare-rust`, then `script/install-test-tools`, then `script/bootstrap`, then `script/test --coverage`.
+- The `privileged-integration` workflow should run only on `ubuntu-24.04`, prepare the pinned Rust toolchain through repository scripts, and invoke `script/test-privileged` for namespace-isolated `network_enforcement_test_only` evidence.
 - Hosted validation should rely on offline defaults from `script/env` after explicit preparation completes.
 - Do not add Rust toolchain setup actions to hosted lint/test/build workflows; use `script/prepare-rust` so the preparation path stays explicit, checksum-gated, and repo-owned.
 - The first publishable agent release build job should run on `ubuntu-24.04`, run `script/validate-locks --ci`, then `script/prepare-rust`, then `script/bootstrap`, then `script/build --release --targets "x86_64-unknown-linux-gnu"`.
@@ -302,6 +310,7 @@ Tests are a design requirement for Fence.
 - Use integration tests for IO and process behavior, but do not substitute a few broad end-to-end tests for meaningful unit coverage.
 - The default first-party target is 100% line, function, and region coverage through `script/test --coverage`.
 - Document explicit coverage exceptions in the change that introduces them. Acceptable exceptions are narrow: unreachable defensive code, platform-specific code not runnable on the current CI host, generated code, or behavior proven by a separate higher-fidelity test harness.
+- `src/nft_backend.rs` is an explicit Phase 2B exception: its privileged execution and kernel-state failure paths are validated by `privileged-integration`, while its deterministic normalization and boundary helpers retain ordinary unit tests.
 - Do not enable branch coverage with `cargo-llvm-cov` until that support is stable. Region coverage is the stable high-granularity gate for now.
 - Do not add `cargo-tarpaulin` or another coverage tool just because it is locally installed; `cargo-llvm-cov` is the repo-owned coverage path.
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,15 @@ CI runners against undeclared outbound network access and ordinary
 runner-privilege bypass paths. The intended first enforcement target is a
 GitHub-hosted `ubuntu-24.04` x64 runner executing a native Linux GNU binary.
 
-Fence is not an enforcement agent yet. The current Phase 2A executable strictly
+Fence is not an enforcement agent yet. The current Phase 2B executable strictly
 validates local JSON policy, renders a frozen policy and deterministic native
 `nftables` ruleset preview, and reports read-only host support observations. It
 never applies a network boundary, changes privilege state, writes readiness, or
 reports protection as available.
+
+Phase 2B additionally exercises native apply, verification, rollback, and
+forwarded-path behavior in disposable privileged test namespaces on
+`ubuntu-24.04`. That evidence is test-only and is not a usable protection mode.
 
 Read [docs/v0.md](docs/v0.md) for the normative v0 security boundary,
 interfaces, proof requirements, and implementation roadmap.
@@ -117,7 +121,7 @@ CI additionally runs `script/validate-locks --ci` and
 runners are not fully air-gapped: checkout, action loading, Rust preparation,
 artifact operations, and release publication still require network access.
 
-## Phase 2A CLI
+## Phase 2 CLI
 
 The current binary emits versioned JSON only. `render-plan` includes the fixed
 `inet fence_v0` ruleset preview, policy hash schema version `2`, and a ruleset
@@ -132,7 +136,7 @@ script/build
 ```
 
 The last command intentionally returns an `enforcement_not_implemented` error
-in Phase 2A. Do not use this planner or its ruleset preview as a runner
+through Phase 2. Do not use this planner or its ruleset preview as a runner
 security control.
 
 ## Release Baseline

--- a/docs/v0.md
+++ b/docs/v0.md
@@ -850,9 +850,10 @@ includes:
 The current Phase 2B Rust CLI implements strict JSON parsing, deterministic
 policy and native-ruleset preview generation, typed expected-state
 verification modeling, and read-only support reporting only. It proves this
-modeling surface but does not implement an enforcement boundary. An internal
-backend applies, reads, verifies, and rolls back the owned table only from
-privileged integration tests and writes evidence status
+modeling surface but does not implement an enforcement boundary. No public
+command or other first-party runtime path invokes the internal backend;
+privileged integration tests exercise native apply, read, verify, and rollback
+operations and write evidence status
 `network_enforcement_test_only` without a readiness file.
 
 ### Offline and online boundaries
@@ -992,8 +993,9 @@ Phase 2 is delivered in three reviewable slices without activating public
    versioned policy/ruleset hashes, deterministic ruleset previews, typed
    expected-state verification models, and read-only backend observation.
 2. Phase 2B implements native `nft` preflight, atomic provisional apply,
-   structured verification, and owned rollback reachable only through
-   privileged namespace-isolated hosted tests.
+   structured verification, and owned rollback; no first-party runtime path
+   invokes it, and privileged namespace-isolated hosted tests provide the
+   behavioral evidence.
 3. Phase 2C implements bounded NFLOG finding ingestion and test evidence after
    explicit dependency and packet-prefix privacy review.
 

--- a/docs/v0.md
+++ b/docs/v0.md
@@ -16,6 +16,8 @@ hermetic Rust CLI that validates and freezes policy, renders a deterministic
 native `nftables` ruleset preview, and reports read-only capability
 observations. It does not apply that preview, write readiness, or establish a
 protection boundary. A packaged planning binary is not a security control.
+Phase 2B also executes native network-policy proof in disposable privileged
+test namespaces; this evidence is not reachable from the public CLI.
 
 The first protected release is deliberately narrow:
 
@@ -845,10 +847,13 @@ includes:
 - SHA-pinned GitHub Actions; and
 - script-first local and CI validation entrypoints.
 
-The current Phase 2A Rust CLI implements strict JSON parsing, deterministic
+The current Phase 2B Rust CLI implements strict JSON parsing, deterministic
 policy and native-ruleset preview generation, typed expected-state
 verification modeling, and read-only support reporting only. It proves this
-modeling surface but does not implement an enforcement boundary.
+modeling surface but does not implement an enforcement boundary. An internal
+backend applies, reads, verifies, and rolls back the owned table only from
+privileged integration tests and writes evidence status
+`network_enforcement_test_only` without a readiness file.
 
 ### Offline and online boundaries
 
@@ -908,19 +913,21 @@ non-enforcing planner is healthy and hermetic:
 - no workflow presents macOS or ARM binaries as protected Fence agent
   releases.
 
-### Future privileged integration workflow
+### Privileged integration workflow
 
-Privileged mode tests must be separate and run only on the supported
-`ubuntu-24.04` x64 hosted environment. They must:
+Phase 2B privileged network evidence runs separately and only on the supported
+`ubuntu-24.04` x64 hosted environment. It must:
 
-- run controlled non-secret destinations;
-- prove dual-stack native nftables behavior;
-- prove audit and block distinctions;
-- prove normal block sudo/container lockdown;
-- prove degraded container-preserving reporting;
-- prove no-restore lifecycle behavior;
-- measure any proposed platform finalization profile; and
+- use disposable network namespaces rather than installing host deny rules;
+- prove dual-stack native nftables block and audit behavior;
+- prove routed forward-chain behavior without claiming container containment;
+- prove singleton ownership, structured verification, and owned rollback;
+- write root-owned test-only evidence without any readiness file; and
 - avoid release or deployment credentials.
+
+Later Phase 3 and Phase 4 privileged tests add sudo/container lockdown,
+no-restore lifecycle behavior, and measurement of any proposed platform
+finalization profile. Those protections are not Phase 2B claims.
 
 ### Release gate
 
@@ -993,6 +1000,12 @@ Phase 2 is delivered in three reviewable slices without activating public
 Throughout Phase 2, privileged evidence is classified
 `network_enforcement_test_only`; it is not protected block mode, and
 forwarded-path evidence is not container-containment proof.
+
+The rootless 100% line/function/region coverage gate excludes the internal
+privileged backend module. That exception is bounded to code whose meaningful
+failure behavior depends on Linux root capabilities and kernel state;
+ordinary unit tests still cover deterministic normalization and boundary
+helpers, and the privileged workflow is the required behavioral proof.
 
 ### Phase 3: Resident service and lockdown
 

--- a/script/test
+++ b/script/test
@@ -43,7 +43,7 @@ html_dir="$DIR/coverage/html"
 
 clear_generated_dir "$DIR/coverage" "coverage output directory"
 
-ignore_regex='(^|/)(tests|benches|target|vendor)/|/\.cargo/registry/|/rustc/'
+ignore_regex='(^|/)(tests|benches|target|vendor)/|/\.cargo/registry/|/rustc/|/src/nft_backend[.]rs$'
 
 cargo llvm-cov clean --workspace
 cargo llvm-cov --frozen --workspace --all-features --no-report

--- a/script/test-privileged
+++ b/script/test-privileged
@@ -1,0 +1,68 @@
+#! /usr/bin/env bash
+
+set -euo pipefail
+
+source script/env "$@"
+
+if [[ $# -ne 0 ]]; then
+  die "usage: script/test-privileged"
+fi
+
+ensure_rust_toolchain
+require_cmd cargo
+require_cmd sudo
+require_cmd ip
+require_cmd python3
+require_cmd ping
+
+if [[ "$PLATFORM" != "linux" || "$ARCH" != "x86_64" ]]; then
+  die "privileged network evidence tests require Linux x86_64"
+fi
+if [[ ! -x /usr/sbin/nft ]]; then
+  die "privileged network evidence tests require executable /usr/sbin/nft"
+fi
+
+evidence_root="$(make_temp_dir fence-privileged-evidence "$RUNNER_TEMP")"
+probe_namespace="fence-probe-$$"
+target_root="$RUNNER_TEMP/fence-privileged-target"
+mkdir -p "$target_root"
+
+cleanup() {
+  sudo /usr/sbin/ip netns del "$probe_namespace" >/dev/null 2>&1 || true
+  if [[ -d "$evidence_root" ]]; then
+    sudo chown -R "$(id -u):$(id -g)" "$evidence_root" >/dev/null 2>&1 || true
+    remove_generated_path "$evidence_root" "privileged evidence directory" || true
+  fi
+}
+trap cleanup EXIT
+
+sudo /usr/sbin/ip netns add "$probe_namespace"
+sudo /usr/sbin/ip -n "$probe_namespace" link set lo up
+sudo /usr/sbin/ip netns exec "$probe_namespace" /usr/sbin/nft list ruleset >/dev/null
+sudo /usr/sbin/ip netns exec "$probe_namespace" /usr/sbin/ip -6 addr show dev lo >/dev/null
+
+# Parse a bounded NFLOG rule in an isolated namespace; userspace event ingestion is Phase 2C.
+printf '%s\n' \
+  'create table inet fence_probe' \
+  'add chain inet fence_probe output { type filter hook output priority 10; policy accept; }' \
+  'add rule inet fence_probe output limit rate 100/second burst 100 packets log group 4242 prefix "fence-probe" queue-threshold 1 snaplen 64 accept' |
+  sudo /usr/sbin/ip netns exec "$probe_namespace" /usr/sbin/nft -f -
+
+export CARGO_TARGET_DIR="$target_root"
+cargo test --frozen --test privileged --no-run
+
+sudo env \
+  "PATH=$PATH" \
+  "HOME=$HOME" \
+  "CARGO_HOME=${CARGO_HOME:-$HOME/.cargo}" \
+  "RUSTUP_HOME=${RUSTUP_HOME:-$HOME/.rustup}" \
+  "CARGO_NET_OFFLINE=$CARGO_NET_OFFLINE" \
+  "RUSTUP_OFFLINE=$RUSTUP_OFFLINE" \
+  "RUSTUP_AUTO_INSTALL=$RUSTUP_AUTO_INSTALL" \
+  "RUNNER_TEMP=$RUNNER_TEMP" \
+  "TMPDIR=${TMPDIR:-$RUNNER_TEMP}" \
+  "CARGO_TARGET_DIR=$CARGO_TARGET_DIR" \
+  "FENCE_PRIVILEGED_TEST_ROOT=$evidence_root" \
+  cargo test --frozen --test privileged -- --ignored --test-threads=1
+
+echo -e "${GREEN}privileged network enforcement test evidence verified${OFF}"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@ pub mod cli;
 pub mod config;
 pub mod error;
 pub mod nft;
+#[doc(hidden)]
+pub mod nft_backend;
 pub mod output;
 pub mod plan;
 pub mod resolver;

--- a/src/nft.rs
+++ b/src/nft.rs
@@ -275,22 +275,22 @@ pub fn render_ruleset(mode: Mode, allowances: &[EffectiveAllowance]) -> String {
     .unwrap();
     writeln!(
         &mut program,
-        "add chain {NFT_FAMILY} {NFT_TABLE} {NFT_CLASSIFY_CHAIN}"
-    )
-    .unwrap();
-    writeln!(
-        &mut program,
-        "add chain {NFT_FAMILY} {NFT_TABLE} {NFT_VIOLATION_CHAIN}"
-    )
-    .unwrap();
-    writeln!(
-        &mut program,
         "add chain {NFT_FAMILY} {NFT_TABLE} {NFT_OUTPUT_CHAIN} {{ type filter hook output priority {NFT_HOOK_PRIORITY}; policy accept; }}"
     )
     .unwrap();
     writeln!(
         &mut program,
         "add chain {NFT_FAMILY} {NFT_TABLE} {NFT_FORWARD_CHAIN} {{ type filter hook forward priority {NFT_HOOK_PRIORITY}; policy accept; }}"
+    )
+    .unwrap();
+    writeln!(
+        &mut program,
+        "add chain {NFT_FAMILY} {NFT_TABLE} {NFT_CLASSIFY_CHAIN}"
+    )
+    .unwrap();
+    writeln!(
+        &mut program,
+        "add chain {NFT_FAMILY} {NFT_TABLE} {NFT_VIOLATION_CHAIN}"
     )
     .unwrap();
     for rule in build_rules(mode, allowances) {

--- a/src/nft_backend.rs
+++ b/src/nft_backend.rs
@@ -1,0 +1,1233 @@
+use crate::config::MAX_REPORT_BYTES;
+use crate::nft::{
+    NFT_CLASSIFY_CHAIN, NFT_FAMILY, NFT_FORWARD_CHAIN, NFT_OUTPUT_CHAIN,
+    NFT_SAMPLED_VIOLATIONS_COUNTER, NFT_TABLE, NFT_TOTAL_VIOLATIONS_COUNTER, NFT_VIOLATION_CHAIN,
+    NetworkEvidence, OwnedChain, OwnedNftState, OwnedRule, VerificationFailure, verify_owned_state,
+};
+use serde::Serialize;
+use serde_json::Value;
+use std::fs::{self, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+pub const NFT_BINARY_PATH: &str = "/usr/sbin/nft";
+pub const IP_BINARY_PATH: &str = "/usr/sbin/ip";
+pub const COMMAND_OUTPUT_LIMIT_BYTES: usize = 1024 * 1024;
+pub const COMMAND_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct BackendError {
+    pub code: &'static str,
+    pub message: String,
+}
+
+impl BackendError {
+    fn new(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+}
+
+impl From<VerificationFailure> for BackendError {
+    fn from(failure: VerificationFailure) -> Self {
+        Self::new(failure.code, failure.message)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum NftOperation {
+    Preflight,
+    ApplyProvisional,
+    ReadOwnedState,
+    ReadTotalViolationsCounter,
+    DeleteOwnedState,
+}
+
+impl NftOperation {
+    fn arguments(self) -> &'static [&'static str] {
+        match self {
+            Self::Preflight => &["-c", "-f", "-"],
+            Self::ApplyProvisional => &["-f", "-"],
+            Self::ReadOwnedState => &["-j", "-n", "-y", "list", "table", NFT_FAMILY, NFT_TABLE],
+            Self::ReadTotalViolationsCounter => &[
+                "-j",
+                "-n",
+                "-y",
+                "list",
+                "counter",
+                NFT_FAMILY,
+                NFT_TABLE,
+                NFT_TOTAL_VIOLATIONS_COUNTER,
+            ],
+            Self::DeleteOwnedState => &["delete", "table", NFT_FAMILY, NFT_TABLE],
+        }
+    }
+}
+
+pub trait NftExecutor {
+    fn execute(&self, operation: NftOperation, input: &[u8]) -> Result<Vec<u8>, BackendError>;
+}
+
+#[derive(Debug, Clone)]
+pub struct SystemNftExecutor {
+    executable: PathBuf,
+    prefix_arguments: Vec<String>,
+}
+
+impl SystemNftExecutor {
+    pub fn host() -> Self {
+        Self {
+            executable: PathBuf::from(NFT_BINARY_PATH),
+            prefix_arguments: Vec::new(),
+        }
+    }
+
+    pub fn in_test_network_namespace(namespace: &str) -> Result<Self, BackendError> {
+        validate_test_identifier(namespace)?;
+        Ok(Self {
+            executable: PathBuf::from(IP_BINARY_PATH),
+            prefix_arguments: vec![
+                "netns".to_owned(),
+                "exec".to_owned(),
+                namespace.to_owned(),
+                NFT_BINARY_PATH.to_owned(),
+            ],
+        })
+    }
+}
+
+impl NftExecutor for SystemNftExecutor {
+    fn execute(&self, operation: NftOperation, input: &[u8]) -> Result<Vec<u8>, BackendError> {
+        let arguments = self
+            .prefix_arguments
+            .iter()
+            .map(String::as_str)
+            .chain(operation.arguments().iter().copied())
+            .collect::<Vec<_>>();
+        run_process_bounded(
+            &self.executable,
+            &arguments,
+            input,
+            COMMAND_TIMEOUT,
+            COMMAND_OUTPUT_LIMIT_BYTES,
+        )
+    }
+}
+
+pub struct NativeNftBackend<E: NftExecutor> {
+    executor: E,
+    created_table: bool,
+}
+
+impl<E: NftExecutor> NativeNftBackend<E> {
+    pub fn new(executor: E) -> Self {
+        Self {
+            executor,
+            created_table: false,
+        }
+    }
+
+    pub fn preflight(&self, program: &str) -> Result<(), BackendError> {
+        self.executor
+            .execute(NftOperation::Preflight, program.as_bytes())
+            .map(|_| ())
+    }
+
+    pub fn apply_provisional(&mut self, program: &str) -> Result<(), BackendError> {
+        self.executor
+            .execute(NftOperation::ApplyProvisional, program.as_bytes())?;
+        self.created_table = true;
+        Ok(())
+    }
+
+    pub fn read_owned_state(&self) -> Result<OwnedNftState, BackendError> {
+        let bytes = self.executor.execute(NftOperation::ReadOwnedState, &[])?;
+        parse_owned_state(&bytes)
+    }
+
+    pub fn verify_owned_state(&self, expected: &OwnedNftState) -> Result<(), BackendError> {
+        let observed = self.read_owned_state()?;
+        verify_owned_state(expected, &observed).map_err(BackendError::from)
+    }
+
+    pub fn total_violation_packets(&self) -> Result<u64, BackendError> {
+        let bytes = self
+            .executor
+            .execute(NftOperation::ReadTotalViolationsCounter, &[])?;
+        parse_counter_packets(&bytes, NFT_TOTAL_VIOLATIONS_COUNTER)
+    }
+
+    pub fn rollback_pre_activation(&mut self) -> Result<bool, BackendError> {
+        if !self.created_table {
+            return Ok(false);
+        }
+        self.executor.execute(NftOperation::DeleteOwnedState, &[])?;
+        self.created_table = false;
+        Ok(true)
+    }
+}
+
+#[derive(Debug)]
+struct CapturedOutput {
+    bytes: Vec<u8>,
+    overflowed: bool,
+}
+
+fn run_process_bounded(
+    executable: &Path,
+    arguments: &[&str],
+    input: &[u8],
+    timeout: Duration,
+    output_limit: usize,
+) -> Result<Vec<u8>, BackendError> {
+    let mut command = Command::new(executable);
+    command
+        .args(arguments)
+        .env_clear()
+        .env("LC_ALL", "C")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = command.spawn().map_err(|error| {
+        BackendError::new("nft_spawn_failed", bounded_message(&error.to_string()))
+    })?;
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| BackendError::new("nft_stdin_failed", "failed to open nft stdin"))?;
+    stdin.write_all(input).map_err(|error| {
+        BackendError::new("nft_stdin_failed", bounded_message(&error.to_string()))
+    })?;
+    drop(stdin);
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| BackendError::new("nft_stdout_failed", "failed to capture nft stdout"))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| BackendError::new("nft_stderr_failed", "failed to capture nft stderr"))?;
+    let stdout_reader = thread::spawn(move || read_bounded(stdout, output_limit));
+    let stderr_reader = thread::spawn(move || read_bounded(stderr, output_limit));
+    let deadline = Instant::now() + timeout;
+
+    let status = loop {
+        if let Some(status) = child.try_wait().map_err(|error| {
+            BackendError::new("nft_wait_failed", bounded_message(&error.to_string()))
+        })? {
+            break status;
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = stdout_reader.join();
+            let _ = stderr_reader.join();
+            return Err(BackendError::new(
+                "nft_command_timeout",
+                "nft command exceeded its execution deadline",
+            ));
+        }
+        thread::sleep(Duration::from_millis(5));
+    };
+
+    let stdout = stdout_reader
+        .join()
+        .map_err(|_| BackendError::new("nft_stdout_failed", "nft stdout reader failed"))?
+        .map_err(|error| {
+            BackendError::new("nft_stdout_failed", bounded_message(&error.to_string()))
+        })?;
+    let stderr = stderr_reader
+        .join()
+        .map_err(|_| BackendError::new("nft_stderr_failed", "nft stderr reader failed"))?
+        .map_err(|error| {
+            BackendError::new("nft_stderr_failed", bounded_message(&error.to_string()))
+        })?;
+    if stdout.overflowed || stderr.overflowed {
+        return Err(BackendError::new(
+            "nft_output_too_large",
+            "nft command output exceeded its fixed capture limit",
+        ));
+    }
+    if !status.success() {
+        return Err(BackendError::new(
+            "nft_command_failed",
+            bounded_message(&String::from_utf8_lossy(&stderr.bytes)),
+        ));
+    }
+    Ok(stdout.bytes)
+}
+
+fn read_bounded(mut stream: impl Read, limit: usize) -> std::io::Result<CapturedOutput> {
+    let mut bytes = Vec::new();
+    let mut overflowed = false;
+    let mut chunk = [0_u8; 4096];
+    loop {
+        let read = stream.read(&mut chunk)?;
+        if read == 0 {
+            break;
+        }
+        let available = limit.saturating_sub(bytes.len());
+        let retained = available.min(read);
+        bytes.extend_from_slice(&chunk[..retained]);
+        overflowed |= retained < read;
+    }
+    Ok(CapturedOutput { bytes, overflowed })
+}
+
+fn bounded_message(message: &str) -> String {
+    const MAX_MESSAGE_BYTES: usize = 512;
+    if message.len() <= MAX_MESSAGE_BYTES {
+        return message.to_owned();
+    }
+    let mut end = MAX_MESSAGE_BYTES;
+    while !message.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}...", &message[..end])
+}
+
+fn parse_owned_state(bytes: &[u8]) -> Result<OwnedNftState, BackendError> {
+    let document: Value = serde_json::from_slice(bytes)
+        .map_err(|_| BackendError::new("invalid_nft_json", "nft returned invalid JSON output"))?;
+    let items = document
+        .get("nftables")
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            BackendError::new("invalid_nft_json", "nft JSON is missing its object list")
+        })?;
+    let mut table_found = false;
+    let mut chains = Vec::new();
+    let mut counters = Vec::new();
+    let mut rules = Vec::new();
+
+    for item in items {
+        let object = item.as_object().ok_or_else(|| {
+            BackendError::new("unexpected_nft_state", "nft object is not structured")
+        })?;
+        if object.contains_key("metainfo") {
+            continue;
+        }
+        if let Some(table) = object.get("table") {
+            require_owned_table(table)?;
+            table_found = true;
+            continue;
+        }
+        if let Some(chain) = object.get("chain") {
+            require_owned_object(chain)?;
+            chains.push(parse_chain(chain)?);
+            continue;
+        }
+        if let Some(counter) = object.get("counter") {
+            require_owned_object(counter)?;
+            counters.push(require_string(counter, "name")?.to_owned());
+            continue;
+        }
+        if let Some(rule) = object.get("rule") {
+            require_owned_object(rule)?;
+            rules.push(parse_rule(rule)?);
+            continue;
+        }
+        return Err(BackendError::new(
+            "unexpected_nft_state",
+            "owned nftables table contains an unexpected object",
+        ));
+    }
+
+    if !table_found {
+        return Err(BackendError::new(
+            "unexpected_nft_state",
+            "owned nftables table is absent from structured state",
+        ));
+    }
+    chains.sort_by_key(chain_rank);
+    counters.sort_by_key(|counter| counter_rank(counter));
+    Ok(OwnedNftState {
+        family: NFT_FAMILY.to_owned(),
+        table: NFT_TABLE.to_owned(),
+        chains,
+        counters,
+        rules,
+    })
+}
+
+fn parse_counter_packets(bytes: &[u8], name: &str) -> Result<u64, BackendError> {
+    let document: Value = serde_json::from_slice(bytes)
+        .map_err(|_| BackendError::new("invalid_nft_json", "nft returned invalid JSON output"))?;
+    let items = document
+        .get("nftables")
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            BackendError::new("invalid_nft_json", "nft JSON is missing its object list")
+        })?;
+    for item in items {
+        let Some(counter) = item.get("counter") else {
+            continue;
+        };
+        require_owned_object(counter)?;
+        if require_string(counter, "name")? == name {
+            return counter
+                .get("packets")
+                .and_then(Value::as_u64)
+                .ok_or_else(|| {
+                    BackendError::new("unexpected_nft_state", "counter has no packet value")
+                });
+        }
+    }
+    Err(BackendError::new(
+        "unexpected_nft_state",
+        "requested owned counter is absent",
+    ))
+}
+
+fn require_owned_table(value: &Value) -> Result<(), BackendError> {
+    if require_string(value, "family")? != NFT_FAMILY || require_string(value, "name")? != NFT_TABLE
+    {
+        return Err(BackendError::new(
+            "unexpected_nft_state",
+            "nft JSON contains an unexpected table",
+        ));
+    }
+    Ok(())
+}
+
+fn require_owned_object(value: &Value) -> Result<(), BackendError> {
+    if require_string(value, "family")? != NFT_FAMILY
+        || require_string(value, "table")? != NFT_TABLE
+    {
+        return Err(BackendError::new(
+            "unexpected_nft_state",
+            "nft JSON contains an object outside the owned table",
+        ));
+    }
+    Ok(())
+}
+
+fn chain_rank(chain: &OwnedChain) -> u8 {
+    let name = match chain {
+        OwnedChain::Base { name, .. } | OwnedChain::Regular { name } => name.as_str(),
+    };
+    match name {
+        NFT_OUTPUT_CHAIN => 0,
+        NFT_FORWARD_CHAIN => 1,
+        NFT_CLASSIFY_CHAIN => 2,
+        NFT_VIOLATION_CHAIN => 3,
+        _ => 4,
+    }
+}
+
+fn counter_rank(counter: &str) -> u8 {
+    match counter {
+        NFT_SAMPLED_VIOLATIONS_COUNTER => 0,
+        NFT_TOTAL_VIOLATIONS_COUNTER => 1,
+        _ => 2,
+    }
+}
+
+fn parse_chain(value: &Value) -> Result<OwnedChain, BackendError> {
+    let name = require_string(value, "name")?.to_owned();
+    match name.as_str() {
+        NFT_OUTPUT_CHAIN | NFT_FORWARD_CHAIN => Ok(OwnedChain::Base {
+            name,
+            chain_type: require_string(value, "type")?.to_owned(),
+            hook: require_string(value, "hook")?.to_owned(),
+            priority: require_i64(value, "prio")?.try_into().map_err(|_| {
+                BackendError::new("unexpected_nft_state", "nft chain priority is out of range")
+            })?,
+            policy: require_string(value, "policy")?.to_owned(),
+        }),
+        NFT_CLASSIFY_CHAIN | NFT_VIOLATION_CHAIN => Ok(OwnedChain::Regular { name }),
+        _ => Err(BackendError::new(
+            "unexpected_nft_state",
+            "owned nftables table contains an unexpected chain",
+        )),
+    }
+}
+
+fn parse_rule(value: &Value) -> Result<OwnedRule, BackendError> {
+    let chain = require_string(value, "chain")?.to_owned();
+    let comment = require_string(value, "comment")?;
+    let expressions = value.get("expr").and_then(Value::as_array).ok_or_else(|| {
+        BackendError::new("unexpected_nft_state", "nft rule has no expression array")
+    })?;
+    match comment {
+        "fence:loopback" if has_accept(expressions) && has_scalar(expressions, "lo") => {
+            Ok(OwnedRule::Loopback { chain })
+        }
+        "fence:established"
+            if has_accept(expressions)
+                && has_scalar(expressions, "established")
+                && has_scalar(expressions, "related") =>
+        {
+            Ok(OwnedRule::EstablishedRelated { chain })
+        }
+        "fence:implicit_ipv6_control"
+            if has_accept(expressions)
+                && has_number(expressions, 255)
+                && has_scalar(expressions, "nd-router-solicit")
+                && has_scalar(expressions, "nd-neighbor-solicit")
+                && has_scalar(expressions, "nd-neighbor-advert") =>
+        {
+            Ok(OwnedRule::ImplicitIpv6Control {
+                chain,
+                icmpv6_types: vec![
+                    "router_solicitation".to_owned(),
+                    "neighbor_solicitation".to_owned(),
+                    "neighbor_advertisement".to_owned(),
+                ],
+                required_hop_limit: 255,
+            })
+        }
+        "fence:classify" if has_jump(expressions, NFT_CLASSIFY_CHAIN) => {
+            Ok(OwnedRule::ClassifyDispatch { chain })
+        }
+        "fence:allowance" if has_accept(expressions) => parse_allowance_rule(chain, expressions),
+        "fence:violation" if has_jump(expressions, NFT_VIOLATION_CHAIN) => {
+            Ok(OwnedRule::ViolationDispatch { chain })
+        }
+        "fence:sample_violation"
+            if has_named_counter(expressions, NFT_SAMPLED_VIOLATIONS_COUNTER) =>
+        {
+            parse_sampled_rule(chain, expressions)
+        }
+        "fence:reject_violation"
+            if has_named_counter(expressions, NFT_TOTAL_VIOLATIONS_COUNTER)
+                && has_key(expressions, "reject") =>
+        {
+            Ok(OwnedRule::TerminalViolation {
+                chain,
+                verdict: "reject".to_owned(),
+            })
+        }
+        "fence:accept_violation"
+            if has_named_counter(expressions, NFT_TOTAL_VIOLATIONS_COUNTER)
+                && has_accept(expressions) =>
+        {
+            Ok(OwnedRule::TerminalViolation {
+                chain,
+                verdict: "accept".to_owned(),
+            })
+        }
+        _ => Err(BackendError::new(
+            "unexpected_nft_state",
+            "owned nftables table contains an unrecognized or malformed rule",
+        )),
+    }
+}
+
+fn parse_allowance_rule(chain: String, expressions: &[Value]) -> Result<OwnedRule, BackendError> {
+    let (address_family, destination) = extract_destination(expressions)?;
+    let (protocol, port) = extract_transport(expressions)?;
+    Ok(OwnedRule::Allowance {
+        chain,
+        address_family,
+        destination,
+        protocol,
+        port,
+    })
+}
+
+fn parse_sampled_rule(chain: String, expressions: &[Value]) -> Result<OwnedRule, BackendError> {
+    let log = find_expression(expressions, "log").ok_or_else(|| {
+        BackendError::new(
+            "unexpected_nft_state",
+            "owned logging rule omits its log expression",
+        )
+    })?;
+    let prefix = log.get("prefix").and_then(Value::as_str).ok_or_else(|| {
+        BackendError::new(
+            "unexpected_nft_state",
+            "owned logging rule omits its prefix",
+        )
+    })?;
+    if !matches!(prefix, "fence-v0-block" | "fence-v0-audit") {
+        return Err(BackendError::new(
+            "unexpected_nft_state",
+            "owned logging rule has an unexpected prefix",
+        ));
+    }
+    let group = log.get("group").and_then(Value::as_u64);
+    let snaplen = log.get("snaplen").and_then(Value::as_u64);
+    let queue_threshold = log
+        .get("qthreshold")
+        .or_else(|| log.get("queue-threshold"))
+        .and_then(Value::as_u64);
+    let limit = find_expression(expressions, "limit").ok_or_else(|| {
+        BackendError::new(
+            "unexpected_nft_state",
+            "owned logging rule omits its rate limit",
+        )
+    })?;
+    let rate = limit.get("rate").and_then(Value::as_u64);
+    let per = limit.get("per").and_then(Value::as_str);
+    let burst = limit.get("burst").and_then(Value::as_u64);
+    if group != Some(4242)
+        || snaplen != Some(64)
+        || queue_threshold != Some(1)
+        || rate != Some(100)
+        || per != Some("second")
+        || burst != Some(100)
+    {
+        return Err(BackendError::new(
+            "unexpected_nft_state",
+            "owned logging rule does not match fixed NFLOG values",
+        ));
+    }
+    Ok(OwnedRule::SampledViolation {
+        chain,
+        nflog_group: 4242,
+        prefix: prefix.to_owned(),
+        packet_prefix_bytes: 64,
+        sample_rate_per_second: 100,
+        sample_burst: 100,
+    })
+}
+
+fn find_expression<'a>(expressions: &'a [Value], key: &str) -> Option<&'a Value> {
+    expressions
+        .iter()
+        .find_map(|expression| expression.get(key))
+}
+
+fn has_named_counter(expressions: &[Value], name: &str) -> bool {
+    let Some(counter) = find_expression(expressions, "counter") else {
+        return false;
+    };
+    match counter {
+        Value::String(value) => value == name,
+        Value::Object(value) => value.get("name").and_then(Value::as_str) == Some(name),
+        _ => false,
+    }
+}
+
+fn extract_destination(expressions: &[Value]) -> Result<(String, String), BackendError> {
+    for expression in expressions {
+        let Some(matcher) = expression.get("match") else {
+            continue;
+        };
+        let Some(left) = matcher.get("left").and_then(|left| left.get("payload")) else {
+            continue;
+        };
+        let protocol = left.get("protocol").and_then(Value::as_str);
+        let field = left.get("field").and_then(Value::as_str);
+        if !matches!(
+            (protocol, field),
+            (Some("ip"), Some("daddr")) | (Some("ip6"), Some("daddr"))
+        ) {
+            continue;
+        }
+        let family = protocol.unwrap().to_owned();
+        let right = matcher.get("right").ok_or_else(|| {
+            BackendError::new("unexpected_nft_state", "allowance destination is absent")
+        })?;
+        if let Some(address) = right.as_str() {
+            return Ok((family, address.to_owned()));
+        }
+        if let Some(prefix) = right.get("prefix") {
+            let address = require_string(prefix, "addr")?;
+            let length = require_i64(prefix, "len")?;
+            return Ok((family, format!("{address}/{length}")));
+        }
+    }
+    Err(BackendError::new(
+        "unexpected_nft_state",
+        "allowance rule does not contain a typed destination",
+    ))
+}
+
+fn extract_transport(expressions: &[Value]) -> Result<(String, u16), BackendError> {
+    for expression in expressions {
+        let Some(matcher) = expression.get("match") else {
+            continue;
+        };
+        let Some(left) = matcher.get("left").and_then(|left| left.get("payload")) else {
+            continue;
+        };
+        let protocol = left.get("protocol").and_then(Value::as_str);
+        let field = left.get("field").and_then(Value::as_str);
+        if !matches!(
+            (protocol, field),
+            (Some("tcp"), Some("dport")) | (Some("udp"), Some("dport"))
+        ) {
+            continue;
+        }
+        let port = matcher
+            .get("right")
+            .and_then(Value::as_u64)
+            .and_then(|port| u16::try_from(port).ok())
+            .ok_or_else(|| {
+                BackendError::new(
+                    "unexpected_nft_state",
+                    "allowance transport port is invalid",
+                )
+            })?;
+        return Ok((protocol.unwrap().to_owned(), port));
+    }
+    Err(BackendError::new(
+        "unexpected_nft_state",
+        "allowance rule does not contain a typed transport",
+    ))
+}
+
+fn has_accept(expressions: &[Value]) -> bool {
+    has_key(expressions, "accept")
+}
+
+fn has_jump(expressions: &[Value], target: &str) -> bool {
+    expressions
+        .iter()
+        .any(|expression| expression.get("jump").and_then(Value::as_str) == Some(target))
+}
+
+fn has_key(expressions: &[Value], key: &str) -> bool {
+    expressions
+        .iter()
+        .any(|expression| expression.get(key).is_some())
+}
+
+fn has_scalar(expressions: &[Value], expected: &str) -> bool {
+    expressions
+        .iter()
+        .any(|expression| value_contains_scalar(expression, expected))
+}
+
+fn value_contains_scalar(value: &Value, expected: &str) -> bool {
+    match value {
+        Value::String(value) => value == expected,
+        Value::Array(values) => values
+            .iter()
+            .any(|value| value_contains_scalar(value, expected)),
+        Value::Object(values) => values
+            .values()
+            .any(|value| value_contains_scalar(value, expected)),
+        _ => false,
+    }
+}
+
+fn has_number(expressions: &[Value], expected: i64) -> bool {
+    expressions
+        .iter()
+        .any(|expression| value_contains_number(expression, expected))
+}
+
+fn value_contains_number(value: &Value, expected: i64) -> bool {
+    match value {
+        Value::Number(value) => value.as_i64() == Some(expected),
+        Value::Array(values) => values
+            .iter()
+            .any(|value| value_contains_number(value, expected)),
+        Value::Object(values) => values
+            .values()
+            .any(|value| value_contains_number(value, expected)),
+        _ => false,
+    }
+}
+
+fn require_string<'a>(value: &'a Value, field: &str) -> Result<&'a str, BackendError> {
+    value.get(field).and_then(Value::as_str).ok_or_else(|| {
+        BackendError::new(
+            "unexpected_nft_state",
+            format!("nft object is missing {field}"),
+        )
+    })
+}
+
+fn require_i64(value: &Value, field: &str) -> Result<i64, BackendError> {
+    value.get(field).and_then(Value::as_i64).ok_or_else(|| {
+        BackendError::new(
+            "unexpected_nft_state",
+            format!("nft object is missing {field}"),
+        )
+    })
+}
+
+fn validate_test_identifier(identifier: &str) -> Result<(), BackendError> {
+    let valid = !identifier.is_empty()
+        && identifier.len() <= 64
+        && identifier
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+        && !identifier.starts_with('-')
+        && !identifier.ends_with('-');
+    if valid {
+        Ok(())
+    } else {
+        Err(BackendError::new(
+            "invalid_test_identifier",
+            "test namespace and evidence identifiers must be bounded slugs",
+        ))
+    }
+}
+
+#[derive(Serialize)]
+struct TestStateDocument<'a> {
+    status: &'static str,
+    owned_state: &'a OwnedNftState,
+}
+
+pub fn write_test_evidence(
+    root: &Path,
+    invocation_id: &str,
+    evidence: &NetworkEvidence,
+    owned_state: &OwnedNftState,
+) -> Result<PathBuf, BackendError> {
+    validate_test_identifier(invocation_id)?;
+    fs::create_dir_all(root).map_err(|error| {
+        BackendError::new("evidence_io_failed", bounded_message(&error.to_string()))
+    })?;
+    set_directory_mode(root, 0o700)?;
+    let directory = root.join(invocation_id);
+    fs::create_dir(&directory).map_err(|error| {
+        BackendError::new("evidence_io_failed", bounded_message(&error.to_string()))
+    })?;
+    set_directory_mode(&directory, 0o700)?;
+    let state = serde_json::to_vec(&TestStateDocument {
+        status: "network_enforcement_test_only",
+        owned_state,
+    })
+    .map_err(|_| {
+        BackendError::new(
+            "evidence_serialization_failed",
+            "failed to serialize test state",
+        )
+    })?;
+    let report = serde_json::to_vec(evidence).map_err(|_| {
+        BackendError::new(
+            "evidence_serialization_failed",
+            "failed to serialize test report",
+        )
+    })?;
+    if report.len() > MAX_REPORT_BYTES {
+        return Err(BackendError::new(
+            "evidence_report_too_large",
+            "test evidence report exceeds the fixed report limit",
+        ));
+    }
+    write_exclusive(&directory.join("state.json"), &state, 0o600)?;
+    write_exclusive(&directory.join("report.json"), &report, 0o644)?;
+    Ok(directory)
+}
+
+fn write_exclusive(path: &Path, bytes: &[u8], mode: u32) -> Result<(), BackendError> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(mode)
+        .open(path)
+        .map_err(|error| {
+            BackendError::new("evidence_io_failed", bounded_message(&error.to_string()))
+        })?;
+    file.write_all(bytes).map_err(|error| {
+        BackendError::new("evidence_io_failed", bounded_message(&error.to_string()))
+    })
+}
+
+fn set_directory_mode(path: &Path, mode: u32) -> Result<(), BackendError> {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::set_permissions(path, fs::Permissions::from_mode(mode)).map_err(|error| {
+        BackendError::new("evidence_io_failed", bounded_message(&error.to_string()))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{DestinationType, Mode, Protocol};
+    use crate::nft::{
+        NETWORK_EVIDENCE_STATUS, expected_owned_state, unapplied_test_evidence_model,
+    };
+    use crate::plan::EffectiveAllowance;
+    use serde_json::json;
+    use std::cell::RefCell;
+    use std::os::unix::fs::PermissionsExt;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static TEST_DIRECTORY_INDEX: AtomicUsize = AtomicUsize::new(0);
+
+    struct FakeExecutor {
+        responses: RefCell<Vec<Result<Vec<u8>, BackendError>>>,
+        operations: RefCell<Vec<NftOperation>>,
+    }
+
+    impl FakeExecutor {
+        fn with_responses(responses: Vec<Result<Vec<u8>, BackendError>>) -> Self {
+            Self {
+                responses: RefCell::new(responses),
+                operations: RefCell::new(Vec::new()),
+            }
+        }
+    }
+
+    impl NftExecutor for FakeExecutor {
+        fn execute(&self, operation: NftOperation, _input: &[u8]) -> Result<Vec<u8>, BackendError> {
+            self.operations.borrow_mut().push(operation);
+            self.responses.borrow_mut().remove(0)
+        }
+    }
+
+    fn allowances() -> Vec<EffectiveAllowance> {
+        vec![
+            EffectiveAllowance {
+                destination_type: DestinationType::Ip,
+                destination: "192.0.2.10".to_owned(),
+                protocol: Protocol::Tcp,
+                port: 443,
+            },
+            EffectiveAllowance {
+                destination_type: DestinationType::Cidr,
+                destination: "2001:db8::/64".to_owned(),
+                protocol: Protocol::Udp,
+                port: 53,
+            },
+        ]
+    }
+
+    fn object(kind: &str, value: Value) -> Value {
+        json!({ kind: value })
+    }
+
+    fn rule(chain: &str, comment: &str, expressions: Value) -> Value {
+        object(
+            "rule",
+            json!({
+                "family": NFT_FAMILY,
+                "table": NFT_TABLE,
+                "chain": chain,
+                "comment": comment,
+                "expr": expressions
+            }),
+        )
+    }
+
+    fn active_state_json(mode: Mode) -> Vec<u8> {
+        let (prefix, terminal_comment, terminal) = match mode {
+            Mode::Block => (
+                "fence-v0-block",
+                "fence:reject_violation",
+                json!({"reject": null}),
+            ),
+            Mode::Audit => (
+                "fence-v0-audit",
+                "fence:accept_violation",
+                json!({"accept": null}),
+            ),
+        };
+        let objects = vec![
+            json!({"metainfo": {"json_schema_version": 1}}),
+            object("table", json!({"family": NFT_FAMILY, "name": NFT_TABLE})),
+            object(
+                "chain",
+                json!({"family": NFT_FAMILY, "table": NFT_TABLE, "name": NFT_CLASSIFY_CHAIN}),
+            ),
+            object(
+                "chain",
+                json!({"family": NFT_FAMILY, "table": NFT_TABLE, "name": NFT_OUTPUT_CHAIN, "type": "filter", "hook": "output", "prio": 10, "policy": "accept"}),
+            ),
+            object(
+                "chain",
+                json!({"family": NFT_FAMILY, "table": NFT_TABLE, "name": NFT_VIOLATION_CHAIN}),
+            ),
+            object(
+                "chain",
+                json!({"family": NFT_FAMILY, "table": NFT_TABLE, "name": NFT_FORWARD_CHAIN, "type": "filter", "hook": "forward", "prio": 10, "policy": "accept"}),
+            ),
+            object(
+                "counter",
+                json!({"family": NFT_FAMILY, "table": NFT_TABLE, "name": NFT_TOTAL_VIOLATIONS_COUNTER}),
+            ),
+            object(
+                "counter",
+                json!({"family": NFT_FAMILY, "table": NFT_TABLE, "name": NFT_SAMPLED_VIOLATIONS_COUNTER}),
+            ),
+            rule(
+                NFT_OUTPUT_CHAIN,
+                "fence:loopback",
+                json!([{"match": {"left": {"meta": {"key": "oifname"}}, "op": "==", "right": "lo"}}, {"accept": null}]),
+            ),
+            rule(
+                NFT_OUTPUT_CHAIN,
+                "fence:established",
+                json!([{"match": {"left": {"ct": {"key": "state"}}, "op": "in", "right": ["established", "related"]}}, {"accept": null}]),
+            ),
+            rule(
+                NFT_OUTPUT_CHAIN,
+                "fence:implicit_ipv6_control",
+                json!([{"match": {"left": {"payload": {"protocol": "ip6", "field": "hoplimit"}}, "op": "==", "right": 255}}, {"match": {"left": {"payload": {"protocol": "icmpv6", "field": "type"}}, "op": "in", "right": ["nd-router-solicit", "nd-neighbor-solicit", "nd-neighbor-advert"]}}, {"accept": null}]),
+            ),
+            rule(
+                NFT_OUTPUT_CHAIN,
+                "fence:classify",
+                json!([{"jump": NFT_CLASSIFY_CHAIN}]),
+            ),
+            rule(
+                NFT_FORWARD_CHAIN,
+                "fence:established",
+                json!([{"match": {"left": {"ct": {"key": "state"}}, "op": "in", "right": ["established", "related"]}}, {"accept": null}]),
+            ),
+            rule(
+                NFT_FORWARD_CHAIN,
+                "fence:classify",
+                json!([{"jump": NFT_CLASSIFY_CHAIN}]),
+            ),
+            rule(
+                NFT_CLASSIFY_CHAIN,
+                "fence:allowance",
+                json!([{"match": {"left": {"payload": {"protocol": "ip", "field": "daddr"}}, "op": "==", "right": "192.0.2.10"}}, {"match": {"left": {"payload": {"protocol": "tcp", "field": "dport"}}, "op": "==", "right": 443}}, {"accept": null}]),
+            ),
+            rule(
+                NFT_CLASSIFY_CHAIN,
+                "fence:allowance",
+                json!([{"match": {"left": {"payload": {"protocol": "ip6", "field": "daddr"}}, "op": "==", "right": {"prefix": {"addr": "2001:db8::", "len": 64}}}}, {"match": {"left": {"payload": {"protocol": "udp", "field": "dport"}}, "op": "==", "right": 53}}, {"accept": null}]),
+            ),
+            rule(
+                NFT_CLASSIFY_CHAIN,
+                "fence:violation",
+                json!([{"jump": NFT_VIOLATION_CHAIN}]),
+            ),
+            rule(
+                NFT_VIOLATION_CHAIN,
+                "fence:sample_violation",
+                json!([{"limit": {"rate": 100, "per": "second", "burst": 100}}, {"counter": {"name": NFT_SAMPLED_VIOLATIONS_COUNTER}}, {"log": {"group": 4242, "prefix": prefix, "snaplen": 64, "qthreshold": 1}}]),
+            ),
+            rule(
+                NFT_VIOLATION_CHAIN,
+                terminal_comment,
+                json!([{"counter": {"name": NFT_TOTAL_VIOLATIONS_COUNTER}}, terminal]),
+            ),
+        ];
+        serde_json::to_vec(&json!({"nftables": objects})).unwrap()
+    }
+
+    #[test]
+    fn backend_preflights_applies_verifies_and_rolls_back_owned_state_only() {
+        let executor = FakeExecutor::with_responses(vec![
+            Ok(Vec::new()),
+            Ok(Vec::new()),
+            Ok(active_state_json(Mode::Block)),
+            Ok(Vec::new()),
+        ]);
+        let mut backend = NativeNftBackend::new(executor);
+
+        assert!(!backend.rollback_pre_activation().unwrap());
+        backend.preflight("program").unwrap();
+        backend.apply_provisional("program").unwrap();
+        backend
+            .verify_owned_state(&expected_owned_state(Mode::Block, &allowances()))
+            .unwrap();
+        assert!(backend.rollback_pre_activation().unwrap());
+        assert_eq!(
+            *backend.executor.operations.borrow(),
+            vec![
+                NftOperation::Preflight,
+                NftOperation::ApplyProvisional,
+                NftOperation::ReadOwnedState,
+                NftOperation::DeleteOwnedState
+            ]
+        );
+    }
+
+    #[test]
+    fn backend_refuses_mismatched_or_failed_provisional_state() {
+        let executor = FakeExecutor::with_responses(vec![Ok(active_state_json(Mode::Block))]);
+        let backend = NativeNftBackend::new(executor);
+        assert_eq!(
+            backend
+                .verify_owned_state(&expected_owned_state(Mode::Audit, &allowances()))
+                .unwrap_err()
+                .code,
+            "owned_nft_state_mismatch"
+        );
+
+        let executor =
+            FakeExecutor::with_responses(vec![Err(BackendError::new("apply_failed", "no table"))]);
+        let mut backend = NativeNftBackend::new(executor);
+        assert_eq!(
+            backend.apply_provisional("invalid").unwrap_err().code,
+            "apply_failed"
+        );
+        assert!(!backend.rollback_pre_activation().unwrap());
+    }
+
+    #[test]
+    fn backend_reads_structured_total_violation_counter() {
+        let counter = serde_json::to_vec(&json!({
+            "nftables": [
+                {"counter": {"family": NFT_FAMILY, "table": NFT_TABLE, "name": NFT_TOTAL_VIOLATIONS_COUNTER, "packets": 7, "bytes": 400}}
+            ]
+        }))
+        .unwrap();
+        let backend = NativeNftBackend::new(FakeExecutor::with_responses(vec![Ok(counter)]));
+
+        assert_eq!(backend.total_violation_packets().unwrap(), 7);
+        assert_eq!(
+            *backend.executor.operations.borrow(),
+            vec![NftOperation::ReadTotalViolationsCounter]
+        );
+    }
+
+    #[test]
+    fn parser_rejects_foreign_objects_and_malformed_rules() {
+        let foreign = serde_json::to_vec(&json!({
+            "nftables": [{"table": {"family": "inet", "name": "foreign"}}]
+        }))
+        .unwrap();
+        assert_eq!(
+            parse_owned_state(&foreign).unwrap_err().code,
+            "unexpected_nft_state"
+        );
+
+        let malformed = serde_json::to_vec(&json!({
+            "nftables": [
+                {"table": {"family": NFT_FAMILY, "name": NFT_TABLE}},
+                {"rule": {"family": NFT_FAMILY, "table": NFT_TABLE, "chain": NFT_VIOLATION_CHAIN, "comment": "fence:sample_violation", "expr": [{"counter": {"name": NFT_SAMPLED_VIOLATIONS_COUNTER}}, {"log": {"group": 1, "prefix": "fence-v0-block", "snaplen": 64, "qthreshold": 1}}, {"limit": {"rate": 100, "per": "second", "burst": 100}}]}}
+            ]
+        }))
+        .unwrap();
+        assert_eq!(
+            parse_owned_state(&malformed).unwrap_err().code,
+            "unexpected_nft_state"
+        );
+        assert_eq!(
+            parse_owned_state(b"[]").unwrap_err().code,
+            "invalid_nft_json"
+        );
+    }
+
+    #[test]
+    fn subprocess_runner_bounds_output_error_and_deadline() {
+        let echoed = run_process_bounded(
+            Path::new("/bin/cat"),
+            &[],
+            b"rules",
+            Duration::from_secs(1),
+            32,
+        )
+        .unwrap();
+        assert_eq!(echoed, b"rules");
+
+        let failed = run_process_bounded(
+            Path::new("/bin/sh"),
+            &["-c", "printf denied >&2; exit 3"],
+            b"",
+            Duration::from_secs(1),
+            32,
+        )
+        .unwrap_err();
+        assert_eq!(failed.code, "nft_command_failed");
+        assert_eq!(failed.message, "denied");
+
+        let overflow = run_process_bounded(
+            Path::new("/bin/sh"),
+            &["-c", "printf 123456789"],
+            b"",
+            Duration::from_secs(1),
+            4,
+        )
+        .unwrap_err();
+        assert_eq!(overflow.code, "nft_output_too_large");
+
+        let timeout = run_process_bounded(
+            Path::new("/bin/sleep"),
+            &["1"],
+            b"",
+            Duration::from_millis(1),
+            32,
+        )
+        .unwrap_err();
+        assert_eq!(timeout.code, "nft_command_timeout");
+
+        let missing = run_process_bounded(
+            Path::new("/missing/fence-command"),
+            &[],
+            b"",
+            Duration::from_secs(1),
+            32,
+        )
+        .unwrap_err();
+        assert_eq!(missing.code, "nft_spawn_failed");
+        assert!(bounded_message(&"x".repeat(600)).ends_with("..."));
+    }
+
+    #[test]
+    fn executor_selects_fixed_host_or_bounded_test_namespace_command() {
+        let host = SystemNftExecutor::host();
+        assert_eq!(host.executable, PathBuf::from(NFT_BINARY_PATH));
+        assert!(host.prefix_arguments.is_empty());
+
+        let namespace = SystemNftExecutor::in_test_network_namespace("proof-1").unwrap();
+        assert_eq!(namespace.executable, PathBuf::from(IP_BINARY_PATH));
+        assert_eq!(namespace.prefix_arguments[2], "proof-1");
+        assert_eq!(
+            SystemNftExecutor::in_test_network_namespace("../host")
+                .unwrap_err()
+                .code,
+            "invalid_test_identifier"
+        );
+    }
+
+    #[test]
+    fn evidence_writer_creates_only_bounded_non_ready_files() {
+        let index = TEST_DIRECTORY_INDEX.fetch_add(1, Ordering::Relaxed);
+        let root = PathBuf::from(format!("target/tmp/nft-evidence-unit-{index}"));
+        let _ = fs::remove_dir_all(&root);
+        let evidence =
+            unapplied_test_evidence_model(Mode::Audit, "policy".to_owned(), "ruleset".to_owned());
+        assert_eq!(evidence.status, NETWORK_EVIDENCE_STATUS);
+
+        let directory = write_test_evidence(
+            &root,
+            "proof-1",
+            &evidence,
+            &expected_owned_state(Mode::Audit, &[]),
+        )
+        .unwrap();
+        assert_eq!(
+            fs::metadata(directory.join("state.json"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+        assert_eq!(
+            fs::metadata(directory.join("report.json"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o644
+        );
+        assert!(!directory.join("ready.json").exists());
+        assert_eq!(
+            write_test_evidence(
+                &root,
+                "proof-1",
+                &evidence,
+                &expected_owned_state(Mode::Audit, &[])
+            )
+            .unwrap_err()
+            .code,
+            "evidence_io_failed"
+        );
+        assert_eq!(
+            write_test_evidence(
+                &root,
+                "../bad",
+                &evidence,
+                &expected_owned_state(Mode::Audit, &[])
+            )
+            .unwrap_err()
+            .code,
+            "invalid_test_identifier"
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/src/nft_backend.rs
+++ b/src/nft_backend.rs
@@ -741,9 +741,13 @@ fn has_implicit_ipv6_control(expressions: &[Value]) -> bool {
 }
 
 fn has_jump(expressions: &[Value], target: &str) -> bool {
-    expressions
-        .iter()
-        .any(|expression| expression.get("jump").and_then(Value::as_str) == Some(target))
+    expressions.iter().any(|expression| {
+        expression
+            .get("jump")
+            .and_then(|jump| jump.get("target"))
+            .and_then(Value::as_str)
+            == Some(target)
+    })
 }
 
 fn has_key(expressions: &[Value], key: &str) -> bool {
@@ -1008,7 +1012,7 @@ mod tests {
             rule(
                 NFT_OUTPUT_CHAIN,
                 "fence:classify",
-                json!([{"jump": NFT_CLASSIFY_CHAIN}]),
+                json!([{"jump": {"target": NFT_CLASSIFY_CHAIN}}]),
             ),
             rule(
                 NFT_FORWARD_CHAIN,
@@ -1018,7 +1022,7 @@ mod tests {
             rule(
                 NFT_FORWARD_CHAIN,
                 "fence:classify",
-                json!([{"jump": NFT_CLASSIFY_CHAIN}]),
+                json!([{"jump": {"target": NFT_CLASSIFY_CHAIN}}]),
             ),
             rule(
                 NFT_CLASSIFY_CHAIN,
@@ -1033,7 +1037,7 @@ mod tests {
             rule(
                 NFT_CLASSIFY_CHAIN,
                 "fence:violation",
-                json!([{"jump": NFT_VIOLATION_CHAIN}]),
+                json!([{"jump": {"target": NFT_VIOLATION_CHAIN}}]),
             ),
             rule(
                 NFT_VIOLATION_CHAIN,

--- a/src/nft_backend.rs
+++ b/src/nft_backend.rs
@@ -515,7 +515,7 @@ fn parse_rule(value: &Value) -> Result<OwnedRule, BackendError> {
         }
         _ => Err(BackendError::new(
             "unexpected_nft_state",
-            "owned nftables table contains an unrecognized or malformed rule",
+            format!("owned nftables table contains malformed rule class {comment}"),
         )),
     }
 }

--- a/src/nft_backend.rs
+++ b/src/nft_backend.rs
@@ -515,7 +515,11 @@ fn parse_rule(value: &Value) -> Result<OwnedRule, BackendError> {
         }
         _ => Err(BackendError::new(
             "unexpected_nft_state",
-            format!("owned nftables table contains malformed rule class {comment}"),
+            bounded_message(&format!(
+                "owned nftables table contains malformed rule class {comment}: {}",
+                serde_json::to_string(expressions)
+                    .unwrap_or_else(|_| "structured-expression-unavailable".to_owned())
+            )),
         )),
     }
 }

--- a/src/nft_backend.rs
+++ b/src/nft_backend.rs
@@ -515,8 +515,14 @@ fn parse_rule(value: &Value) -> Result<OwnedRule, BackendError> {
 }
 
 fn parse_allowance_rule(chain: String, expressions: &[Value]) -> Result<OwnedRule, BackendError> {
-    let (address_family, destination) = extract_destination(expressions)?;
-    let (protocol, port) = extract_transport(expressions)?;
+    if expressions.len() != 3 || expressions[2].get("accept").is_none() {
+        return Err(BackendError::new(
+            "unexpected_nft_state",
+            "allowance rule does not have the exact expected expression shape",
+        ));
+    }
+    let (address_family, destination) = extract_destination(&expressions[..1])?;
+    let (protocol, port) = extract_transport(&expressions[1..2])?;
     Ok(OwnedRule::Allowance {
         chain,
         address_family,
@@ -615,6 +621,12 @@ fn extract_destination(expressions: &[Value]) -> Result<(String, String), Backen
         ) {
             continue;
         }
+        if matcher.get("op").and_then(Value::as_str) != Some("==") {
+            return Err(BackendError::new(
+                "unexpected_nft_state",
+                "allowance destination does not use equality matching",
+            ));
+        }
         let family = protocol.unwrap().to_owned();
         let right = matcher.get("right").ok_or_else(|| {
             BackendError::new("unexpected_nft_state", "allowance destination is absent")
@@ -649,6 +661,12 @@ fn extract_transport(expressions: &[Value]) -> Result<(String, u16), BackendErro
             (Some("tcp"), Some("dport")) | (Some("udp"), Some("dport"))
         ) {
             continue;
+        }
+        if matcher.get("op").and_then(Value::as_str) != Some("==") {
+            return Err(BackendError::new(
+                "unexpected_nft_state",
+                "allowance transport does not use equality matching",
+            ));
         }
         let port = matcher
             .get("right")
@@ -1141,6 +1159,52 @@ mod tests {
         assert_eq!(
             parse_owned_state(b"[]").unwrap_err().code,
             "invalid_nft_json"
+        );
+
+        let unequal_destination = json!([
+            {"match": {"left": {"payload": {"protocol": "ip", "field": "daddr"}}, "op": "!=", "right": "192.0.2.10"}},
+            {"match": {"left": {"payload": {"protocol": "tcp", "field": "dport"}}, "op": "==", "right": 443}},
+            {"accept": null}
+        ]);
+        assert_eq!(
+            parse_allowance_rule(
+                NFT_CLASSIFY_CHAIN.to_owned(),
+                unequal_destination.as_array().unwrap()
+            )
+            .unwrap_err()
+            .code,
+            "unexpected_nft_state"
+        );
+
+        let unequal_port = json!([
+            {"match": {"left": {"payload": {"protocol": "ip", "field": "daddr"}}, "op": "==", "right": "192.0.2.10"}},
+            {"match": {"left": {"payload": {"protocol": "tcp", "field": "dport"}}, "op": "!=", "right": 443}},
+            {"accept": null}
+        ]);
+        assert_eq!(
+            parse_allowance_rule(
+                NFT_CLASSIFY_CHAIN.to_owned(),
+                unequal_port.as_array().unwrap()
+            )
+            .unwrap_err()
+            .code,
+            "unexpected_nft_state"
+        );
+
+        let unexpected_extra_match = json!([
+            {"match": {"left": {"payload": {"protocol": "ip", "field": "daddr"}}, "op": "==", "right": "192.0.2.10"}},
+            {"match": {"left": {"payload": {"protocol": "tcp", "field": "dport"}}, "op": "==", "right": 443}},
+            {"match": {"left": {"payload": {"protocol": "tcp", "field": "sport"}}, "op": "==", "right": 12345}},
+            {"accept": null}
+        ]);
+        assert_eq!(
+            parse_allowance_rule(
+                NFT_CLASSIFY_CHAIN.to_owned(),
+                unexpected_extra_match.as_array().unwrap()
+            )
+            .unwrap_err()
+            .code,
+            "unexpected_nft_state"
         );
     }
 

--- a/src/nft_backend.rs
+++ b/src/nft_backend.rs
@@ -465,11 +465,7 @@ fn parse_rule(value: &Value) -> Result<OwnedRule, BackendError> {
             Ok(OwnedRule::EstablishedRelated { chain })
         }
         "fence:implicit_ipv6_control"
-            if has_accept(expressions)
-                && has_number(expressions, 255)
-                && has_scalar(expressions, "nd-router-solicit")
-                && has_scalar(expressions, "nd-neighbor-solicit")
-                && has_scalar(expressions, "nd-neighbor-advert") =>
+            if has_accept(expressions) && has_implicit_ipv6_control(expressions) =>
         {
             Ok(OwnedRule::ImplicitIpv6Control {
                 chain,
@@ -699,6 +695,51 @@ fn has_established_related_state(expressions: &[Value]) -> bool {
     })
 }
 
+fn has_implicit_ipv6_control(expressions: &[Value]) -> bool {
+    let hop_limit = expressions.iter().any(|expression| {
+        let Some(matcher) = expression.get("match") else {
+            return false;
+        };
+        matcher
+            .get("left")
+            .and_then(|left| left.get("payload"))
+            .and_then(|payload| payload.get("protocol"))
+            .and_then(Value::as_str)
+            == Some("ip6")
+            && matcher
+                .get("left")
+                .and_then(|left| left.get("payload"))
+                .and_then(|payload| payload.get("field"))
+                .and_then(Value::as_str)
+                == Some("hoplimit")
+            && matcher.get("right").and_then(Value::as_u64) == Some(255)
+    });
+    let control_types = expressions.iter().any(|expression| {
+        let Some(matcher) = expression.get("match") else {
+            return false;
+        };
+        let is_icmp_type = matcher
+            .get("left")
+            .and_then(|left| left.get("payload"))
+            .and_then(|payload| payload.get("protocol"))
+            .and_then(Value::as_str)
+            == Some("icmpv6")
+            && matcher
+                .get("left")
+                .and_then(|left| left.get("payload"))
+                .and_then(|payload| payload.get("field"))
+                .and_then(Value::as_str)
+                == Some("type");
+        let types = matcher
+            .get("right")
+            .and_then(|right| right.get("set"))
+            .and_then(Value::as_array)
+            .map(|types| types.iter().filter_map(Value::as_u64).collect::<Vec<_>>());
+        is_icmp_type && types.as_deref() == Some(&[133, 135, 136])
+    });
+    hop_limit && control_types
+}
+
 fn has_jump(expressions: &[Value], target: &str) -> bool {
     expressions
         .iter()
@@ -726,25 +767,6 @@ fn value_contains_scalar(value: &Value, expected: &str) -> bool {
         Value::Object(values) => values
             .values()
             .any(|value| value_contains_scalar(value, expected)),
-        _ => false,
-    }
-}
-
-fn has_number(expressions: &[Value], expected: i64) -> bool {
-    expressions
-        .iter()
-        .any(|expression| value_contains_number(expression, expected))
-}
-
-fn value_contains_number(value: &Value, expected: i64) -> bool {
-    match value {
-        Value::Number(value) => value.as_i64() == Some(expected),
-        Value::Array(values) => values
-            .iter()
-            .any(|value| value_contains_number(value, expected)),
-        Value::Object(values) => values
-            .values()
-            .any(|value| value_contains_number(value, expected)),
         _ => false,
     }
 }
@@ -981,7 +1003,7 @@ mod tests {
             rule(
                 NFT_OUTPUT_CHAIN,
                 "fence:implicit_ipv6_control",
-                json!([{"match": {"left": {"payload": {"protocol": "ip6", "field": "hoplimit"}}, "op": "==", "right": 255}}, {"match": {"left": {"payload": {"protocol": "icmpv6", "field": "type"}}, "op": "in", "right": ["nd-router-solicit", "nd-neighbor-solicit", "nd-neighbor-advert"]}}, {"accept": null}]),
+                json!([{"match": {"left": {"payload": {"protocol": "ip6", "field": "hoplimit"}}, "op": "==", "right": 255}}, {"match": {"left": {"payload": {"protocol": "icmpv6", "field": "type"}}, "op": "==", "right": {"set": [133, 135, 136]}}}, {"accept": null}]),
             ),
             rule(
                 NFT_OUTPUT_CHAIN,

--- a/src/nft_backend.rs
+++ b/src/nft_backend.rs
@@ -460,9 +460,7 @@ fn parse_rule(value: &Value) -> Result<OwnedRule, BackendError> {
             Ok(OwnedRule::Loopback { chain })
         }
         "fence:established"
-            if has_accept(expressions)
-                && has_scalar(expressions, "established")
-                && has_scalar(expressions, "related") =>
+            if has_accept(expressions) && has_established_related_state(expressions) =>
         {
             Ok(OwnedRule::EstablishedRelated { chain })
         }
@@ -680,6 +678,25 @@ fn extract_transport(expressions: &[Value]) -> Result<(String, u16), BackendErro
 
 fn has_accept(expressions: &[Value]) -> bool {
     has_key(expressions, "accept")
+}
+
+fn has_established_related_state(expressions: &[Value]) -> bool {
+    expressions.iter().any(|expression| {
+        let Some(matcher) = expression.get("match") else {
+            return false;
+        };
+        let is_ct_state = matcher
+            .get("left")
+            .and_then(|left| left.get("ct"))
+            .and_then(|ct| ct.get("key"))
+            .and_then(Value::as_str)
+            == Some("state");
+        let values = matcher
+            .get("right")
+            .and_then(Value::as_array)
+            .map(|values| values.iter().filter_map(Value::as_u64).collect::<Vec<_>>());
+        is_ct_state && values.as_deref() == Some(&[2, 4])
+    })
 }
 
 fn has_jump(expressions: &[Value], target: &str) -> bool {
@@ -959,7 +976,7 @@ mod tests {
             rule(
                 NFT_OUTPUT_CHAIN,
                 "fence:established",
-                json!([{"match": {"left": {"ct": {"key": "state"}}, "op": "in", "right": ["established", "related"]}}, {"accept": null}]),
+                json!([{"match": {"left": {"ct": {"key": "state"}}, "op": "in", "right": [2, 4]}}, {"accept": null}]),
             ),
             rule(
                 NFT_OUTPUT_CHAIN,
@@ -974,7 +991,7 @@ mod tests {
             rule(
                 NFT_FORWARD_CHAIN,
                 "fence:established",
-                json!([{"match": {"left": {"ct": {"key": "state"}}, "op": "in", "right": ["established", "related"]}}, {"accept": null}]),
+                json!([{"match": {"left": {"ct": {"key": "state"}}, "op": "in", "right": [2, 4]}}, {"accept": null}]),
             ),
             rule(
                 NFT_FORWARD_CHAIN,

--- a/src/nft_backend.rs
+++ b/src/nft_backend.rs
@@ -509,11 +509,7 @@ fn parse_rule(value: &Value) -> Result<OwnedRule, BackendError> {
         }
         _ => Err(BackendError::new(
             "unexpected_nft_state",
-            bounded_message(&format!(
-                "owned nftables table contains malformed rule class {comment}: {}",
-                serde_json::to_string(expressions)
-                    .unwrap_or_else(|_| "structured-expression-unavailable".to_owned())
-            )),
+            format!("owned nftables table contains malformed rule class {comment}"),
         )),
     }
 }

--- a/tests/privileged.rs
+++ b/tests/privileged.rs
@@ -1,0 +1,536 @@
+#![cfg(target_os = "linux")]
+
+use fence::config::{DestinationType, Mode, Protocol, parse_and_normalize};
+use fence::nft::{
+    NetworkEvidenceCounters, expected_owned_state, render_ruleset, unapplied_test_evidence_model,
+};
+use fence::nft_backend::{
+    IP_BINARY_PATH, NativeNftBackend, SystemNftExecutor, write_test_evidence,
+};
+use fence::plan::{EffectiveAllowance, build_plan};
+use fence::resolver::{Resolution, ResolveError, Resolver};
+use std::fs;
+use std::os::unix::fs::MetadataExt;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Output};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread;
+use std::time::{Duration, Instant};
+
+static TEST_INDEX: AtomicUsize = AtomicUsize::new(0);
+const PYTHON: &str = "/usr/bin/python3";
+const PING: &str = "/usr/bin/ping";
+
+struct NoResolver;
+
+impl Resolver for NoResolver {
+    fn resolve(&self, _hostname: &str, _timeout: Duration) -> Result<Resolution, ResolveError> {
+        panic!("privileged fixtures contain concrete destinations only");
+    }
+}
+
+struct PeerTopology {
+    client: String,
+    server: String,
+}
+
+impl PeerTopology {
+    fn new() -> Self {
+        let suffix = unique_suffix();
+        let client = format!("fence-c-{suffix}");
+        let server = format!("fence-s-{suffix}");
+        let client_link = format!("fc{}", &suffix[suffix.len().saturating_sub(6)..]);
+        let server_link = format!("fs{}", &suffix[suffix.len().saturating_sub(6)..]);
+        ip(&["netns", "add", &client]);
+        ip(&["netns", "add", &server]);
+        ip(&[
+            "link",
+            "add",
+            &client_link,
+            "type",
+            "veth",
+            "peer",
+            "name",
+            &server_link,
+        ]);
+        ip(&["link", "set", &client_link, "netns", &client]);
+        ip(&["link", "set", &server_link, "netns", &server]);
+        ip(&["-n", &client, "link", "set", "lo", "up"]);
+        ip(&["-n", &server, "link", "set", "lo", "up"]);
+        ip(&["-n", &client, "link", "set", &client_link, "up"]);
+        ip(&["-n", &server, "link", "set", &server_link, "up"]);
+        ip(&[
+            "-n",
+            &client,
+            "addr",
+            "add",
+            "192.0.2.1/24",
+            "dev",
+            &client_link,
+        ]);
+        ip(&[
+            "-n",
+            &server,
+            "addr",
+            "add",
+            "192.0.2.2/24",
+            "dev",
+            &server_link,
+        ]);
+        ip(&[
+            "-n",
+            &client,
+            "-6",
+            "addr",
+            "add",
+            "2001:db8:1::1/64",
+            "dev",
+            &client_link,
+            "nodad",
+        ]);
+        ip(&[
+            "-n",
+            &server,
+            "-6",
+            "addr",
+            "add",
+            "2001:db8:1::2/64",
+            "dev",
+            &server_link,
+            "nodad",
+        ]);
+        Self { client, server }
+    }
+}
+
+impl Drop for PeerTopology {
+    fn drop(&mut self) {
+        let _ = Command::new(IP_BINARY_PATH)
+            .args(["netns", "del", &self.client])
+            .status();
+        let _ = Command::new(IP_BINARY_PATH)
+            .args(["netns", "del", &self.server])
+            .status();
+    }
+}
+
+struct RoutedTopology {
+    source: String,
+    router: String,
+    sink: String,
+}
+
+impl RoutedTopology {
+    fn new() -> Self {
+        let suffix = unique_suffix();
+        let source = format!("fence-a-{suffix}");
+        let router = format!("fence-r-{suffix}");
+        let sink = format!("fence-b-{suffix}");
+        for namespace in [&source, &router, &sink] {
+            ip(&["netns", "add", namespace]);
+            ip(&["-n", namespace, "link", "set", "lo", "up"]);
+        }
+        connect_namespaces(
+            &source,
+            "as0",
+            &router,
+            "ra0",
+            "198.51.100.2/24",
+            "198.51.100.1/24",
+        );
+        connect_namespaces(
+            &router,
+            "rb0",
+            &sink,
+            "bs0",
+            "203.0.113.1/24",
+            "203.0.113.2/24",
+        );
+        in_namespace(
+            &source,
+            "/usr/sbin/ip",
+            &["route", "add", "203.0.113.0/24", "via", "198.51.100.1"],
+        );
+        in_namespace(
+            &sink,
+            "/usr/sbin/ip",
+            &["route", "add", "198.51.100.0/24", "via", "203.0.113.1"],
+        );
+        in_namespace(
+            &router,
+            "/usr/sbin/sysctl",
+            &["-qw", "net.ipv4.ip_forward=1"],
+        );
+        Self {
+            source,
+            router,
+            sink,
+        }
+    }
+}
+
+impl Drop for RoutedTopology {
+    fn drop(&mut self) {
+        for namespace in [&self.source, &self.router, &self.sink] {
+            let _ = Command::new(IP_BINARY_PATH)
+                .args(["netns", "del", namespace])
+                .status();
+        }
+    }
+}
+
+struct ChildGuard(Child);
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+#[test]
+#[ignore = "requires Linux root network namespaces and native nftables"]
+fn block_and_audit_output_paths_emit_only_test_evidence() {
+    require_root();
+    let topology = PeerTopology::new();
+    let root = evidence_root();
+    fs::create_dir_all(&root).unwrap();
+
+    let block_allowances = vec![
+        allowance("192.0.2.2", Protocol::Tcp, 18443),
+        allowance("192.0.2.2", Protocol::Udp, 18444),
+        allowance("2001:db8:1::2", Protocol::Tcp, 18443),
+        allowance("2001:db8:1::2", Protocol::Udp, 18444),
+    ];
+    let mut block = backend(&topology.client);
+    let block_program = render_ruleset(Mode::Block, &block_allowances);
+    block.preflight(&block_program).unwrap();
+    block.apply_provisional(&block_program).unwrap();
+    block
+        .verify_owned_state(&expected_owned_state(Mode::Block, &block_allowances))
+        .unwrap();
+    assert!(traffic_with_listener(&topology, "192.0.2.2", "tcp", 18443));
+    assert!(traffic_with_listener(&topology, "192.0.2.2", "udp", 18444));
+    assert!(traffic_with_listener(
+        &topology,
+        "2001:db8:1::2",
+        "tcp",
+        18443
+    ));
+    assert!(traffic_with_listener(
+        &topology,
+        "2001:db8:1::2",
+        "udp",
+        18444
+    ));
+    assert!(!traffic_with_listener(&topology, "192.0.2.2", "tcp", 19443));
+    assert!(!traffic_with_listener(&topology, "192.0.2.2", "udp", 19444));
+    assert!(!traffic_with_listener(
+        &topology,
+        "2001:db8:1::2",
+        "tcp",
+        19443
+    ));
+    assert!(!traffic_with_listener(
+        &topology,
+        "2001:db8:1::2",
+        "udp",
+        19444
+    ));
+    assert!(!in_namespace_status(
+        &topology.client,
+        PING,
+        &["-6", "-c", "1", "-W", "1", "2001:db8:1::2"]
+    ));
+    let blocked = block.total_violation_packets().unwrap();
+    assert!(blocked >= 5);
+    let planned = build_plan(
+        parse_and_normalize(br#"{"schema_version":1,"mode":"block","invocation_id":"block-output","allowances":[{"destination_type":"ip","destination":"192.0.2.2","protocol":"tcp","port":18443},{"destination_type":"ip","destination":"192.0.2.2","protocol":"udp","port":18444},{"destination_type":"ip","destination":"2001:db8:1::2","protocol":"tcp","port":18443},{"destination_type":"ip","destination":"2001:db8:1::2","protocol":"udp","port":18444}]}"#).unwrap(),
+        &NoResolver,
+    )
+    .unwrap();
+    assert_eq!(planned.effective_policy, block_allowances);
+    let mut evidence =
+        unapplied_test_evidence_model(Mode::Block, planned.policy_hash, planned.ruleset_hash);
+    evidence.apply_status = "applied";
+    evidence.verification_status = "verified";
+    evidence.counters = NetworkEvidenceCounters {
+        total_violations: blocked,
+        sampled_violations: 0,
+    };
+    let directory = write_test_evidence(
+        &root,
+        "block-output",
+        &evidence,
+        &expected_owned_state(Mode::Block, &block_allowances),
+    )
+    .unwrap();
+    assert_eq!(fs::metadata(directory.join("state.json")).unwrap().uid(), 0);
+    assert_eq!(
+        fs::metadata(directory.join("report.json")).unwrap().uid(),
+        0
+    );
+    assert!(!directory.join("ready.json").exists());
+    assert!(block.rollback_pre_activation().unwrap());
+
+    let audit_allowances = Vec::new();
+    let mut audit = backend(&topology.client);
+    let audit_program = render_ruleset(Mode::Audit, &audit_allowances);
+    audit.preflight(&audit_program).unwrap();
+    audit.apply_provisional(&audit_program).unwrap();
+    audit
+        .verify_owned_state(&expected_owned_state(Mode::Audit, &audit_allowances))
+        .unwrap();
+    assert!(traffic_with_listener(&topology, "192.0.2.2", "tcp", 20443));
+    assert!(traffic_with_listener(
+        &topology,
+        "2001:db8:1::2",
+        "udp",
+        20444
+    ));
+    assert!(audit.total_violation_packets().unwrap() >= 2);
+    assert!(audit.rollback_pre_activation().unwrap());
+}
+
+#[test]
+#[ignore = "requires Linux root network namespaces and native nftables"]
+fn conflict_preflight_and_rollback_are_confined_to_owned_namespace_state() {
+    require_root();
+    let topology = PeerTopology::new();
+    let mut first = backend(&topology.client);
+    let program = render_ruleset(Mode::Block, &[]);
+    first.preflight(&program).unwrap();
+    first.apply_provisional(&program).unwrap();
+    let mut conflict = backend(&topology.client);
+    assert!(conflict.apply_provisional(&program).is_err());
+    assert!(!conflict.rollback_pre_activation().unwrap());
+    assert!(first.rollback_pre_activation().unwrap());
+
+    let invalid =
+        "create table inet fence_v0\nadd chain inet fence_v0 broken { type filter hook output;";
+    let preflight = backend(&topology.client);
+    assert!(preflight.preflight(invalid).is_err());
+
+    nft_in_namespace(&topology.client, &["add", "table", "inet", "foreign_test"]);
+    let mut applied = backend(&topology.client);
+    applied.apply_provisional(&program).unwrap();
+    assert!(
+        applied
+            .verify_owned_state(&expected_owned_state(Mode::Audit, &[]))
+            .is_err()
+    );
+    assert!(applied.rollback_pre_activation().unwrap());
+    nft_in_namespace(&topology.client, &["list", "table", "inet", "foreign_test"]);
+}
+
+#[test]
+#[ignore = "requires Linux root network namespaces and native nftables"]
+fn forward_hook_proves_routed_block_and_audit_behavior_without_containment_claim() {
+    require_root();
+    let topology = RoutedTopology::new();
+    let allowed = vec![allowance("203.0.113.2", Protocol::Tcp, 21443)];
+    let mut block = backend(&topology.router);
+    let program = render_ruleset(Mode::Block, &allowed);
+    block.preflight(&program).unwrap();
+    block.apply_provisional(&program).unwrap();
+    block
+        .verify_owned_state(&expected_owned_state(Mode::Block, &allowed))
+        .unwrap();
+    assert!(routed_traffic(&topology, 21443));
+    assert!(!routed_traffic(&topology, 21444));
+    assert!(block.total_violation_packets().unwrap() >= 1);
+    assert!(block.rollback_pre_activation().unwrap());
+
+    let mut audit = backend(&topology.router);
+    let program = render_ruleset(Mode::Audit, &[]);
+    audit.preflight(&program).unwrap();
+    audit.apply_provisional(&program).unwrap();
+    audit
+        .verify_owned_state(&expected_owned_state(Mode::Audit, &[]))
+        .unwrap();
+    assert!(routed_traffic(&topology, 21445));
+    assert!(audit.total_violation_packets().unwrap() >= 1);
+    assert!(audit.rollback_pre_activation().unwrap());
+}
+
+fn backend(namespace: &str) -> NativeNftBackend<SystemNftExecutor> {
+    NativeNftBackend::new(SystemNftExecutor::in_test_network_namespace(namespace).unwrap())
+}
+
+fn allowance(destination: &str, protocol: Protocol, port: u16) -> EffectiveAllowance {
+    EffectiveAllowance {
+        destination_type: DestinationType::Ip,
+        destination: destination.to_owned(),
+        protocol,
+        port,
+    }
+}
+
+fn unique_suffix() -> String {
+    format!(
+        "{}-{}",
+        std::process::id(),
+        TEST_INDEX.fetch_add(1, Ordering::Relaxed)
+    )
+}
+
+fn evidence_root() -> PathBuf {
+    PathBuf::from(
+        std::env::var_os("FENCE_PRIVILEGED_TEST_ROOT")
+            .expect("script/test-privileged must set FENCE_PRIVILEGED_TEST_ROOT"),
+    )
+}
+
+fn require_root() {
+    let output = run_output("/usr/bin/id", &["-u"]);
+    assert_eq!(String::from_utf8(output.stdout).unwrap().trim(), "0");
+}
+
+fn ip(arguments: &[&str]) {
+    must_succeed(run_output(IP_BINARY_PATH, arguments));
+}
+
+fn nft_in_namespace(namespace: &str, arguments: &[&str]) {
+    let mut args = vec!["netns", "exec", namespace, "/usr/sbin/nft"];
+    args.extend_from_slice(arguments);
+    must_succeed(run_output(IP_BINARY_PATH, &args));
+}
+
+fn connect_namespaces(
+    left: &str,
+    left_link: &str,
+    right: &str,
+    right_link: &str,
+    left_address: &str,
+    right_address: &str,
+) {
+    ip(&[
+        "link", "add", left_link, "type", "veth", "peer", "name", right_link,
+    ]);
+    ip(&["link", "set", left_link, "netns", left]);
+    ip(&["link", "set", right_link, "netns", right]);
+    ip(&["-n", left, "link", "set", left_link, "up"]);
+    ip(&["-n", right, "link", "set", right_link, "up"]);
+    ip(&["-n", left, "addr", "add", left_address, "dev", left_link]);
+    ip(&["-n", right, "addr", "add", right_address, "dev", right_link]);
+}
+
+fn traffic_with_listener(
+    topology: &PeerTopology,
+    address: &str,
+    protocol: &str,
+    port: u16,
+) -> bool {
+    let ready = evidence_root().join(format!("ready-{protocol}-{port}"));
+    let mut listener = start_listener(&topology.server, address, protocol, port, &ready);
+    wait_for_path(&ready);
+    let success = send_traffic(&topology.client, address, protocol, port);
+    let _ = listener.0.kill();
+    let _ = listener.0.wait();
+    let _ = fs::remove_file(ready);
+    success
+}
+
+fn routed_traffic(topology: &RoutedTopology, port: u16) -> bool {
+    let ready = evidence_root().join(format!("ready-forward-{port}"));
+    let mut listener = start_listener(&topology.sink, "203.0.113.2", "tcp", port, &ready);
+    wait_for_path(&ready);
+    let success = send_traffic(&topology.source, "203.0.113.2", "tcp", port);
+    let _ = listener.0.kill();
+    let _ = listener.0.wait();
+    let _ = fs::remove_file(ready);
+    success
+}
+
+fn start_listener(
+    namespace: &str,
+    address: &str,
+    protocol: &str,
+    port: u16,
+    ready: &Path,
+) -> ChildGuard {
+    let script = r#"
+import socket, sys
+address, protocol, port, ready = sys.argv[1], sys.argv[2], int(sys.argv[3]), sys.argv[4]
+family = socket.AF_INET6 if ":" in address else socket.AF_INET
+kind = socket.SOCK_STREAM if protocol == "tcp" else socket.SOCK_DGRAM
+s = socket.socket(family, kind)
+s.settimeout(5)
+s.bind((address, port))
+if protocol == "tcp":
+    s.listen(1)
+open(ready, "w").write("ready")
+if protocol == "tcp":
+    c, _ = s.accept()
+    c.recv(1)
+    c.send(b"ok")
+else:
+    data, peer = s.recvfrom(8)
+    s.sendto(b"ok", peer)
+"#;
+    let child = Command::new(IP_BINARY_PATH)
+        .args([
+            "netns",
+            "exec",
+            namespace,
+            PYTHON,
+            "-c",
+            script,
+            address,
+            protocol,
+            &port.to_string(),
+            ready.to_str().unwrap(),
+        ])
+        .spawn()
+        .unwrap();
+    ChildGuard(child)
+}
+
+fn send_traffic(namespace: &str, address: &str, protocol: &str, port: u16) -> bool {
+    let script = r#"
+import socket, sys
+address, protocol, port = sys.argv[1], sys.argv[2], int(sys.argv[3])
+family = socket.AF_INET6 if ":" in address else socket.AF_INET
+kind = socket.SOCK_STREAM if protocol == "tcp" else socket.SOCK_DGRAM
+s = socket.socket(family, kind)
+s.settimeout(2)
+s.connect((address, port))
+s.send(b"x")
+assert s.recv(2) == b"ok"
+"#;
+    in_namespace_status(
+        namespace,
+        PYTHON,
+        &["-c", script, address, protocol, &port.to_string()],
+    )
+}
+
+fn wait_for_path(path: &Path) {
+    let deadline = Instant::now() + Duration::from_secs(3);
+    while !path.exists() {
+        assert!(Instant::now() < deadline, "listener did not become ready");
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn in_namespace(namespace: &str, program: &str, arguments: &[&str]) {
+    assert!(in_namespace_status(namespace, program, arguments));
+}
+
+fn in_namespace_status(namespace: &str, program: &str, arguments: &[&str]) -> bool {
+    let mut args = vec!["netns", "exec", namespace, program];
+    args.extend_from_slice(arguments);
+    run_output(IP_BINARY_PATH, &args).status.success()
+}
+
+fn run_output(program: &str, arguments: &[&str]) -> Output {
+    Command::new(program).args(arguments).output().unwrap()
+}
+
+fn must_succeed(output: Output) {
+    assert!(
+        output.status.success(),
+        "command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
## 🔬 Summary

Adds *Phase 2B*'s internal native `nftables` backend and a Linux-only privileged evidence workflow. The backend preflights, applies, reads, verifies, and rolls back singleton `inet fence_v0` state inside disposable network namespaces, with bounded command output and root-owned test reports.

## 🔒 Boundary

Public `fence run` remains fail-closed and no readiness or protection claim is activated. Rootless coverage explicitly delegates the privileged kernel-state boundary to hosted namespace proof.
