### PR TITLE
Add packaged CLI acceptance gate

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -23,8 +23,6 @@ jobs:
   packaged-public-contract:
     name: packaged public contract
     runs-on: ubuntu-24.04
-    env:
-      ACCEPTANCE_DIST: ${{ runner.temp }}/fence-acceptance-dist
 
     steps:
       - name: checkout
@@ -44,13 +42,13 @@ jobs:
       - name: build packaged Linux x64 artifact
         env:
           BUILD_VERSION: acceptance
-        run: script/build --release --targets "x86_64-unknown-linux-gnu" --dist-dir "$ACCEPTANCE_DIST"
+        run: script/build --release --targets "x86_64-unknown-linux-gnu" --dist-dir "$RUNNER_TEMP/fence-acceptance-dist"
 
       - name: verify packaged artifact checksum
-        working-directory: ${{ runner.temp }}/fence-acceptance-dist
         run: |
+          cd "$RUNNER_TEMP/fence-acceptance-dist"
           grep -Eq 'fence_acceptance_linux-amd64$' checksums.txt
           sha256sum -c checksums.txt
 
       - name: exercise packaged public contract
-        run: script/test-package-smoke "$ACCEPTANCE_DIST/fence_acceptance_linux-amd64"
+        run: script/test-package-smoke "$RUNNER_TEMP/fence-acceptance-dist/fence_acceptance_linux-amd64"

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -1,0 +1,56 @@
+name: acceptance
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  packaged-public-contract:
+    name: packaged public contract
+    runs-on: ubuntu-24.04
+    env:
+      ACCEPTANCE_DIST: ${{ runner.temp }}/fence-acceptance-dist
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: validate locks
+        run: script/validate-locks --ci
+
+      - name: prepare rust
+        run: script/prepare-rust
+
+      - name: bootstrap
+        run: script/bootstrap
+
+      - name: build packaged Linux x64 artifact
+        env:
+          BUILD_VERSION: acceptance
+        run: script/build --release --targets "x86_64-unknown-linux-gnu" --dist-dir "$ACCEPTANCE_DIST"
+
+      - name: verify packaged artifact checksum
+        working-directory: ${{ runner.temp }}/fence-acceptance-dist
+        run: |
+          grep -Eq 'fence_acceptance_linux-amd64$' checksums.txt
+          sha256sum -c checksums.txt
+
+      - name: exercise packaged public contract
+        run: script/test-package-smoke "$ACCEPTANCE_DIST/fence_acceptance_linux-amd64"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This repository is the Rust implementation scaffold for Fence, a security agent 
 
 Fence must pass the "airplane test": a normal developer or CI worker should be able to build, test, lint, and package the project without reaching the network after dependencies and toolchains have been explicitly prepared.
 
-The current Phase 2C binary is still non-enforcing: `render-plan` emits a deterministic native `nftables` preview, while `run` fails closed and no code writes readiness or claims protection. No first-party runtime path reaches native apply/verify/rollback or NFLOG ingestion; the repository exercises those paths only through privileged evidence tests. The complete protected lifecycle is a later reviewed change.
+The current Phase 2C binary is still non-enforcing: `render-plan` emits a deterministic native `nftables` preview, while `run` fails closed and no code writes readiness or claims protection. No first-party runtime path reaches native apply/verify/rollback or NFLOG ingestion; the repository exercises those paths only through privileged evidence tests. A separate packaged-artifact acceptance test executes the distributed CLI shape without claiming protection. The complete protected lifecycle and any public GitHub Action wrapper are later reviewed changes.
 
 ## North-Star Principles
 
@@ -27,7 +27,7 @@ The current Phase 2C binary is still non-enforcing: `render-plan` emits a determ
 
 ## Non-Negotiable Policy
 
-- No network calls during `script/bootstrap`, `script/test`, `script/lint`, `script/build`, or `script/server`.
+- No network calls during `script/bootstrap`, `script/test`, `script/test-package-smoke`, `script/lint`, `script/build`, or `script/server`.
 - `script/update` is the only normal Cargo dependency update path and is intentionally online-only.
 - `script/vendor-rust` is the only normal Rust distribution lock refresh path and is intentionally online-only.
 - `script/prepare-rust` is the only normal Rust installation path. It is intentionally online, checksum-gated, and must validate `.cargo/tooling/rust-toolchain.lock.toml` before invoking `rustup`.
@@ -54,8 +54,8 @@ The current Phase 2C binary is still non-enforcing: `render-plan` emits a determ
 
 There are three different levels in this repository. Keep them distinct when editing docs or workflows.
 
-1. Local project workflow: checksum-gated online Rust preparation with `script/prepare-rust` when needed, then offline Cargo validation through vendored sources. `script/bootstrap`, `script/test`, `script/lint`, `script/build`, and `script/server` enforce the offline phase.
-2. GitHub-hosted validation: `lint`, `test`, `coverage`, PR `build`, and release build jobs run `script/validate-locks --ci`, then `script/prepare-rust`, then the normal offline scripts. Hosted runners are not air-gapped infrastructure because checkout, action loading, Rust preparation, and artifact services still use network access.
+1. Local project workflow: checksum-gated online Rust preparation with `script/prepare-rust` when needed, then offline Cargo validation through vendored sources. `script/bootstrap`, `script/test`, `script/test-package-smoke`, `script/lint`, `script/build`, and `script/server` enforce the offline phase.
+2. GitHub-hosted validation: `lint`, `test`, `coverage`, PR `build`, packaged-artifact `acceptance`, and release build jobs run `script/validate-locks --ci`, then `script/prepare-rust`, then the normal offline scripts. Hosted runners are not air-gapped infrastructure because checkout, action loading, Rust preparation, and artifact services still use network access.
 3. Egress-blocked build/package jobs: after checkout, action loading, and Rust preparation, native Linux x64 build/test/package scripts can run without third-party network access because application crates are committed. Retained cross-build-tool smoke jobs additionally install committed tool artifacts offline. Release publish/sign/verify jobs still need GitHub API access.
 
 Do not describe GitHub-hosted runners as fully air-gapped. They can validate offline script behavior, but they are not an egress-blocked environment.
@@ -125,6 +125,12 @@ All scripts live in `script/` and should use `set -euo pipefail` unless there is
   - Runs native apply/verify/rollback and bounded NFLOG collection only inside disposable network namespaces and writes test-only evidence beneath `RUNNER_TEMP`.
   - NFLOG handling may inspect at most the configured 64-byte packet prefix transiently in memory and must serialize approved endpoint metadata only.
   - Must not invoke the public `run` command, create a readiness file, mutate host firewall rules, or make a protection claim.
+
+- `script/test-package-smoke`
+  - Linux x64-only offline packaged-artifact acceptance entrypoint; it accepts exactly one already-built Fence binary path.
+  - Uses only a literal-IP/CIDR policy fixture and Python standard-library JSON parsing; it must not resolve hostnames, install tools, or use network access.
+  - Verifies versioned JSON output, deterministic `render-plan`, fail-closed `run`, no `inet fence_v0` table creation, and no `/run/fence/package-acceptance/` state creation.
+  - Proves only the Phase 2 public CLI contract of a packaged binary; it is distinct from privileged network evidence and cannot make a protection claim.
 
 - `script/lint`
   - Runs format check, clippy, `cargo verify-project`, and docs.
@@ -262,11 +268,13 @@ If any version file changes, update docs and verify the corresponding script beh
 ## CI Expectations
 
 - The `build` workflow is the PR-based native Linux x64 package smoke test. It should validate locks, prepare Rust, run `script/bootstrap`, and run `script/build --release --targets "x86_64-unknown-linux-gnu"` on `ubuntu-24.04`.
+- The `acceptance` workflow should run only on `ubuntu-24.04`, build its own Linux x64 package from the current commit, verify its checksum, and invoke `script/test-package-smoke` as the `packaged public contract` check.
 - The `build` workflow should exercise retained Zig/`cargo-zigbuild` artifacts in a distinct offline install/verify smoke job. That job is not a protected release artifact claim.
 - Hosted lint/test workflows may remain portable on fixed Ubuntu and macOS labels while their behavior is platform-neutral. Protected integration, package, and release jobs target fixed `ubuntu-24.04` x64 only.
 - Hosted lint/test/build workflows should run `script/validate-locks --ci`, then `script/prepare-rust`, then `script/bootstrap`, then their offline validation command or native package-smoke path.
 - Hosted coverage workflows should run `script/validate-locks --ci`, then `script/prepare-rust`, then `script/install-test-tools`, then `script/bootstrap`, then `script/test --coverage`.
 - The `privileged-integration` workflow should run only on `ubuntu-24.04`, prepare the pinned Rust toolchain through repository scripts, and invoke `script/test-privileged` for namespace-isolated `network_enforcement_test_only` evidence.
+- `acceptance` and `privileged-integration` must remain separate evidence boundaries: the former exercises the packaged non-enforcing CLI, while the latter proves privileged kernel/network behavior in disposable namespaces.
 - Hosted validation should rely on offline defaults from `script/env` after explicit preparation completes.
 - Do not add Rust toolchain setup actions to hosted lint/test/build workflows; use `script/prepare-rust` so the preparation path stays explicit, checksum-gated, and repo-owned.
 - The first publishable agent release build job should run on `ubuntu-24.04`, run `script/validate-locks --ci`, then `script/prepare-rust`, then `script/bootstrap`, then `script/build --release --targets "x86_64-unknown-linux-gnu"`.
@@ -297,6 +305,7 @@ If any version file changes, update docs and verify the corresponding script beh
 - Preserve public API stability unless the task explicitly calls for a breaking Fence change.
 - If changing CLI output or release archive layout, update README examples.
 - Until the protected lifecycle is implemented, `run` must remain fail-closed and no first-party code may emit a ready-state protection assertion.
+- Do not add a public `action.yml` wrapper until the protected lifecycle can truthfully report readiness; the intended later wrapper lives in this repository, uses an immutable external reference, carries a reviewed Linux binary, and does not download an agent at runtime.
 
 ## Testing Standards
 
@@ -337,6 +346,7 @@ Update docs in the same PR when changing:
 Use the smallest validation set that proves the change:
 
 - Script/workflow/doc changes: `git diff --check`.
+- Packaged Linux public-contract changes: build the Linux x64 artifact on `ubuntu-24.04`, verify its checksum, then run `script/test-package-smoke <artifact>`.
 - Rust behavior changes: `script/bootstrap`, `script/test`, `script/lint`, and `script/build`.
 - Coverage changes: `script/install-test-tools`, then `script/test --coverage`. Do not add a static coverage badge unless CI enforces and publishes the measured result.
 - Dependency updates: `script/update`, then inspect `Cargo.lock` and `vendor/cache`, then rerun offline validation.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![lint](https://github.com/GrantBirki/fence/actions/workflows/lint.yml/badge.svg)](https://github.com/GrantBirki/fence/actions/workflows/lint.yml)
 [![test](https://github.com/GrantBirki/fence/actions/workflows/test.yml/badge.svg)](https://github.com/GrantBirki/fence/actions/workflows/test.yml)
 [![build](https://github.com/GrantBirki/fence/actions/workflows/build.yml/badge.svg)](https://github.com/GrantBirki/fence/actions/workflows/build.yml)
+[![acceptance](https://github.com/GrantBirki/fence/actions/workflows/acceptance.yml/badge.svg)](https://github.com/GrantBirki/fence/actions/workflows/acceptance.yml)
+[![privileged-integration](https://github.com/GrantBirki/fence/actions/workflows/privileged-integration.yml/badge.svg)](https://github.com/GrantBirki/fence/actions/workflows/privileged-integration.yml)
 
 Fence is an early-stage, source-auditable Rust project for hardening supported
 CI runners against undeclared outbound network access and ordinary
@@ -21,6 +23,11 @@ privileged test namespaces on `ubuntu-24.04`. The event path immediately
 reduces a bounded packet prefix to approved endpoint metadata and never writes
 raw packet bytes to evidence. This is test-only proof, not a usable protection
 mode.
+
+Pull requests also build a Linux x64 package independently and execute that
+artifact through the Phase 2 JSON CLI contract. This proves the distributed
+binary remains non-enforcing and fail-closed; it is not a public GitHub Action
+or a protection claim.
 
 Read [docs/v0.md](docs/v0.md) for the normative v0 security boundary,
 interfaces, proof requirements, and implementation roadmap.
@@ -125,6 +132,9 @@ CI additionally runs `script/validate-locks --ci` and
 `script/prepare-rust` before entering the offline script surface. Hosted
 runners are not fully air-gapped: checkout, action loading, Rust preparation,
 artifact operations, and release publication still require network access.
+On `ubuntu-24.04`, `script/test-package-smoke` verifies the built Linux
+artifact's public non-enforcing contract separately from the privileged
+namespace evidence workflow.
 
 ## Phase 2 CLI
 
@@ -143,6 +153,12 @@ script/build
 The last command intentionally returns an `enforcement_not_implemented` error
 through Phase 2. Do not use this planner or its ruleset preview as a runner
 security control.
+
+A public GitHub Action wrapper is deferred until a later protected lifecycle
+can truthfully establish readiness. That future wrapper is intended to live
+in this repository and carry a reviewed Linux binary in an immutable action
+reference; Phase 2 does not publish an `action.yml` interface or download an
+agent at workflow runtime.
 
 ## Release Baseline
 

--- a/docs/repository-settings.md
+++ b/docs/repository-settings.md
@@ -7,10 +7,14 @@ Some security controls cannot be fully represented in tracked files. Configure t
 - Require a pull request before merging.
 - Require CODEOWNER review.
 - Require status checks before merge:
-  - `lint`
-  - `test`
-  - `coverage`
   - `build`
+  - `coverage`
+  - `lint (macos-14)`
+  - `lint (ubuntu-24.04)`
+  - `packaged public contract`
+  - `privileged network evidence`
+  - `test (macos-14)`
+  - `test (ubuntu-24.04)`
 - Require branches to be up to date before merging if that matches the repository's merge policy.
 - Block force-pushes.
 - Block branch deletion.
@@ -27,7 +31,10 @@ Some security controls cannot be fully represented in tracked files. Configure t
 - Keep portable lint/test validation separate from protected-platform claims; fixed macOS validation does not constitute macOS enforcement support.
 - Protected package and release jobs should run only on GitHub-hosted `ubuntu-24.04` x64 and publish only the `x86_64-unknown-linux-gnu` agent artifact until an additional protected target is implemented and tested.
 - Keep the `build` workflow as the PR-based Linux x64 package smoke test: validate locks, prepare Rust, bootstrap, then run native release-mode packaging.
+- Keep the `acceptance` workflow as the distinct Linux x64 packaged public-contract gate: independently package the current commit, verify its checksum, then execute `script/test-package-smoke`.
+- Keep the `privileged-integration` workflow required as the distinct namespace-isolated native network-evidence gate; it does not assert public protection.
 - Exercise retained Zig/`cargo-zigbuild` inputs through a separate offline installation/verification smoke job; those inputs are reserved for future cross-platform investigation and are not current release artifacts.
+- Do not add a public root `action.yml` before the protected lifecycle exists. A later wrapper should remain in this repository and be consumed externally only through an immutable reference.
 - If an egress-blocking action is added, apply it to build/test/package jobs after checkout and before scripts run. Do not apply it to release publishing, signing, or verification jobs unless those jobs are split into an explicitly GitHub-network-allowed phase.
 
 ## CODEOWNERS

--- a/docs/v0.md
+++ b/docs/v0.md
@@ -2,7 +2,7 @@
 
 Status: normative design for the first implementation
 Audience: maintainers, implementers, security reviewers, and workflow authors
-Last reviewed: 2026-05-27
+Last reviewed: 2026-05-28
 
 ## Purpose
 
@@ -18,7 +18,9 @@ observations. It does not apply that preview, write readiness, or establish a
 protection boundary. A packaged planning binary is not a security control.
 Phase 2C also executes native network-policy and bounded NFLOG finding proof
 in disposable privileged test namespaces; this evidence is not reachable from
-the public CLI.
+the public CLI. A distinct packaged-artifact acceptance path executes the
+Linux x64 binary through its public Phase 2 JSON contract and proves that it
+remains non-enforcing; it does not create a GitHub Action interface.
 
 The first protected release is deliberately narrow:
 
@@ -921,6 +923,10 @@ non-enforcing planner is healthy and hermetic:
 - coverage runs on fixed Ubuntu with committed coverage tooling;
 - PR build packaging runs natively on `ubuntu-24.04` for
   `x86_64-unknown-linux-gnu`;
+- packaged public-contract acceptance independently builds and executes the
+  Linux x64 artifact on `ubuntu-24.04`, proving versioned JSON behavior,
+  deterministic planning, fail-closed `run`, and absence of applied Fence
+  runtime/kernel state;
 - retained cross-build tools are installed and verified in a separate smoke
   path, not as a supported-release artifact requirement; and
 - no workflow presents macOS or ARM binaries as protected Fence agent
@@ -943,6 +949,22 @@ Phase 2C privileged network evidence runs separately and only on the supported
 Later Phase 3 and Phase 4 privileged tests add sudo/container lockdown,
 no-restore lifecycle behavior, and measurement of any proposed platform
 finalization profile. Those protections are not Phase 2C claims.
+
+### Packaged public-contract acceptance workflow
+
+Phase 2 packaged acceptance runs separately from privileged network evidence
+and only on `ubuntu-24.04` x64. It must:
+
+- independently package the current commit as a Linux x64 GNU artifact and
+  verify the generated checksum before execution;
+- invoke the packaged binary, not a Cargo test executable;
+- use an IP/CIDR-only policy fixture so it requires no DNS or remote traffic;
+- prove `--version`, `check-support`, deterministic `render-plan`, and the
+  fail-closed `run` error through versioned JSON output;
+- prove public commands create neither `inet fence_v0` nor planned runtime
+  state under `/run/fence/package-acceptance/`; and
+- remain a non-enforcing artifact-contract test, not readiness or containment
+  evidence.
 
 ### Release gate
 
@@ -1018,6 +1040,10 @@ Throughout Phase 2, privileged evidence is classified
 `network_enforcement_test_only`; it is not protected block mode, and
 forwarded-path evidence is not container-containment proof.
 
+Phase 2 additionally gates the packaged Linux artifact through a public CLI
+acceptance workflow. That workflow does not invoke a root Action wrapper and
+must continue proving that public execution is non-mutating and fail-closed.
+
 The rootless 100% line/function/region coverage gate excludes the internal
 privileged backend and NFLOG socket modules. That exception is bounded to code
 whose meaningful failure behavior depends on Linux root capabilities, kernel
@@ -1056,6 +1082,14 @@ Artifact publication must remain source-built, checksum-verified, and
 attestation-verified. An action wrapper is a subsequent user-facing layer,
 not a prerequisite for proving the agent binary's first local boundary.
 
+A future Action wrapper belongs in this repository at the root so repository
+acceptance can exercise it with `uses: ./`. It is deferred until a protected
+lifecycle can truthfully report readiness. External documentation must use an
+immutable commit SHA or intentionally managed immutable release tag, not a
+floating branch; the wrapper must carry its reviewed Linux binary in that
+immutable source reference and must not download an agent or policy at
+workflow runtime.
+
 ## Test Requirements
 
 ### Tests for the current documentation/workflow pass
@@ -1073,6 +1107,21 @@ not a prerequisite for proving the agent binary's first local boundary.
   machine-specific paths.
 - Hermetic lock validation and existing scaffold test/lint/build/coverage
   scripts still pass.
+
+### Packaged Phase 2 CLI acceptance tests
+
+On `ubuntu-24.04` x64, the packaged public-contract workflow must prove:
+
+- the Linux x64 GNU package checksum verifies before the artifact is executed;
+- `--version` and `check-support` emit JSON that reports Phase 2 and no
+  protection availability;
+- two literal-policy `render-plan` executions are byte-identical and report
+  policy-hash schema version `2`, native `inet fence_v0` preview constants,
+  and `not_applied` / `not_verified` status;
+- `run --config <nonexistent-path>` fails with
+  `enforcement_not_implemented` rather than reading configuration; and
+- no public command creates the owned nftables table or planned runtime
+  directory.
 
 ### Pure Rust tests for Phases 1 And 2A
 
@@ -1146,6 +1195,9 @@ reviewable maintenance model.
 - [GitHub-hosted runners reference](https://docs.github.com/en/actions/reference/runners/github-hosted-runners)
 - [GitHub Ubuntu 24.04 runner image inventory](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md)
 - [GitHub artifact attestations](https://docs.github.com/en/actions/how-tos/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds)
+- [GitHub composite action local-use model](https://docs.github.com/en/actions/tutorials/creating-a-composite-action)
+- [GitHub Actions metadata syntax](https://docs.github.com/en/actions/reference/metadata-syntax-for-github-actions)
+- [GitHub immutable action releases and tags](https://docs.github.com/en/actions/how-tos/create-and-publish-actions/using-immutable-releases-and-tags-to-manage-your-actions-releases)
 - [nftables families](https://wiki.nftables.org/wiki-nftables/index.php/Nftables_families)
 - [nftables man page](https://netfilter.org/projects/nftables/manpage.html)
 - [Docker firewall with nftables](https://docs.docker.com/engine/network/firewall-nftables/)

--- a/script/test-package-smoke
+++ b/script/test-package-smoke
@@ -1,0 +1,236 @@
+#! /usr/bin/env bash
+
+set -euo pipefail
+
+source script/env "$@"
+
+if [[ $# -ne 1 ]]; then
+  die "usage: script/test-package-smoke <path-to-fence-binary>"
+fi
+
+binary="$1"
+fixture="$DIR/tests/fixtures/acceptance/block-literal-policy.json"
+runtime_directory="/run/fence/package-acceptance"
+
+if [[ "$PLATFORM" != "linux" || "$ARCH" != "x86_64" ]]; then
+  die "packaged public-contract smoke tests require Linux x86_64"
+fi
+
+require_cmd python3
+require_cmd sudo
+
+if [[ ! -x /usr/sbin/nft ]]; then
+  die "packaged public-contract smoke tests require executable /usr/sbin/nft"
+fi
+if [[ ! -f "$binary" || ! -x "$binary" ]]; then
+  die "packaged public-contract smoke tests require an executable Fence binary: $binary"
+fi
+if [[ ! -f "$fixture" ]]; then
+  die "missing packaged public-contract fixture: ${fixture#$DIR/}"
+fi
+
+temporary_directory="$(make_temp_dir fence-package-smoke)"
+cleanup() {
+  remove_generated_path "$temporary_directory" "packaged public-contract smoke directory"
+}
+trap cleanup EXIT
+
+assert_no_owned_table() {
+  local phase="$1"
+  local snapshot="$temporary_directory/nft-${phase}.json"
+
+  sudo /usr/sbin/nft -j list tables > "$snapshot"
+  python3 - "$snapshot" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as source:
+    document = json.load(source)
+
+for item in document.get("nftables", []):
+    table = item.get("table")
+    if table and table.get("family") == "inet" and table.get("name") == "fence_v0":
+        raise SystemExit("owned table inet fence_v0 unexpectedly exists")
+PY
+}
+
+assert_no_runtime_state() {
+  if [[ -e "$runtime_directory" ]]; then
+    die "public Phase 2 command unexpectedly created runtime state: $runtime_directory"
+  fi
+}
+
+capture_command() {
+  local label="$1"
+  shift
+  local status
+
+  set +e
+  "$binary" "$@" > "$temporary_directory/${label}.stdout" 2> "$temporary_directory/${label}.stderr"
+  status="$?"
+  set -e
+  printf '%s\n' "$status" > "$temporary_directory/${label}.status"
+}
+
+assert_status() {
+  local label="$1"
+  local expected="$2"
+  local actual
+
+  actual="$(tr -d '[:space:]' < "$temporary_directory/${label}.status")"
+  if [[ "$actual" != "$expected" ]]; then
+    die "unexpected exit status for $label (expected ${expected}, found ${actual})"
+  fi
+}
+
+assert_empty_file() {
+  local path="$1"
+  local description="$2"
+
+  if [[ -s "$path" ]]; then
+    die "$description must be empty"
+  fi
+}
+
+assert_no_owned_table before
+assert_no_runtime_state
+
+capture_command version --version
+assert_status version 0
+assert_empty_file "$temporary_directory/version.stderr" "version stderr"
+python3 - "$temporary_directory/version.stdout" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as source:
+    result = json.load(source)
+
+def require(condition, message):
+    if not condition:
+        raise SystemExit(message)
+
+require(result["schema_version"] == 1, "version response schema mismatch")
+require(result["command"] == "version", "version command field mismatch")
+require(result["status"] == "success", "version response status mismatch")
+require(result["fence_version"] == "0.0.0", "version envelope version mismatch")
+require(result["data"]["implementation_phase"] == "phase2", "version phase mismatch")
+require(result["data"]["protection_available"] is False, "version reported protection")
+PY
+
+capture_command support check-support
+assert_status support 0
+assert_empty_file "$temporary_directory/support.stderr" "check-support stderr"
+python3 - "$temporary_directory/support.stdout" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as source:
+    result = json.load(source)
+
+data = result["data"]
+def require(condition, message):
+    if not condition:
+        raise SystemExit(message)
+
+require(result["schema_version"] == 1, "support response schema mismatch")
+require(result["command"] == "check-support", "support command field mismatch")
+require(result["status"] == "success", "support response status mismatch")
+require(result["fence_version"] == "0.0.0", "support envelope version mismatch")
+require(data["implementation_phase"] == "phase2", "support phase mismatch")
+require(data["intended_protected_target_match"] is True, "support target mismatch")
+require(data["protection_available"] is False, "support reported protection")
+require(
+    "public_enforcement_not_activated" in data["reasons"],
+    "support omitted public-enforcement reason",
+)
+require("lockdown_not_implemented" in data["reasons"], "support omitted lockdown reason")
+require(
+    data["network_backend"]["required"] == "native_nftables",
+    "support backend requirement mismatch",
+)
+require(
+    data["network_backend"]["nft_binary_expected_path"] == "/usr/sbin/nft",
+    "support nft path mismatch",
+)
+require(data["network_backend"]["nft_binary_present"] is True, "support omitted nft binary")
+PY
+
+capture_command plan-first render-plan --config "$fixture"
+capture_command plan-second render-plan --config "$fixture"
+assert_status plan-first 0
+assert_status plan-second 0
+assert_empty_file "$temporary_directory/plan-first.stderr" "first render-plan stderr"
+assert_empty_file "$temporary_directory/plan-second.stderr" "second render-plan stderr"
+cmp -s "$temporary_directory/plan-first.stdout" "$temporary_directory/plan-second.stdout" ||
+  die "render-plan output must be deterministic for the literal-address fixture"
+python3 - "$temporary_directory/plan-first.stdout" <<'PY'
+import json
+import re
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as source:
+    result = json.load(source)
+
+data = result["data"]
+def require(condition, message):
+    if not condition:
+        raise SystemExit(message)
+
+require(result["schema_version"] == 1, "plan response schema mismatch")
+require(result["command"] == "render-plan", "plan command field mismatch")
+require(result["status"] == "success", "plan response status mismatch")
+require(result["fence_version"] == "0.0.0", "plan envelope version mismatch")
+require(data["implementation_phase"] == "phase2", "plan phase mismatch")
+require(data["policy_hash_schema_version"] == 2, "plan policy hash schema mismatch")
+require(re.fullmatch(r"[0-9a-f]{64}", data["policy_hash"]), "invalid policy hash")
+require(re.fullmatch(r"[0-9a-f]{64}", data["ruleset_hash"]), "invalid ruleset hash")
+require(data["application_status"] == "not_applied", "plan reported application")
+require(data["verification_status"] == "not_verified", "plan reported verification")
+require(
+    data["derived_runtime_paths"]["directory"] == "/run/fence/package-acceptance",
+    "plan runtime directory mismatch",
+)
+require(
+    data["network_enforcement_preview"]["activation_status"] == "not_applied",
+    "network preview reported activation",
+)
+require(
+    data["network_enforcement_preview"]["owned_table"]
+    == {"family": "inet", "name": "fence_v0", "single_active_invocation": True},
+    "owned table preview mismatch",
+)
+require(data["network_enforcement_preview"]["nflog"]["group"] == 4242, "nflog group mismatch")
+PY
+
+sentinel="$temporary_directory/nonexistent-run-config.json"
+capture_command run run --config "$sentinel"
+assert_status run 1
+assert_empty_file "$temporary_directory/run.stdout" "run stdout"
+python3 - "$temporary_directory/run.stderr" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as source:
+    result = json.load(source)
+
+def require(condition, message):
+    if not condition:
+        raise SystemExit(message)
+
+require(result["schema_version"] == 1, "run response schema mismatch")
+require(result["command"] == "run", "run command field mismatch")
+require(result["status"] == "error", "run response status mismatch")
+require(result["fence_version"] == "0.0.0", "run envelope version mismatch")
+require(
+    result["error"]["code"] == "enforcement_not_implemented",
+    "run did not fail closed",
+)
+PY
+if [[ -e "$sentinel" ]]; then
+  die "run unexpectedly materialized its nonexistent configuration path"
+fi
+
+assert_no_owned_table after
+assert_no_runtime_state
+
+echo -e "${GREEN}packaged public Phase 2 CLI contract verified${OFF}"

--- a/tests/fixtures/acceptance/block-literal-policy.json
+++ b/tests/fixtures/acceptance/block-literal-policy.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "mode": "block",
+  "invocation_id": "package-acceptance",
+  "platform_profile": "none",
+  "container_policy": "disable",
+  "allowances": [
+    {
+      "destination_type": "ip",
+      "destination": "192.0.2.10",
+      "protocol": "tcp",
+      "port": 443
+    },
+    {
+      "destination_type": "cidr",
+      "destination": "2001:db8::/64",
+      "protocol": "udp",
+      "port": 53
+    }
+  ]
+}


### PR DESCRIPTION
## 🧪 Summary

Adds a standalone *packaged public contract* acceptance gate that builds the Linux x64 artifact from the PR head and proves the Phase 2 JSON interface remains deterministic, non-mutating, and fail-closed.

## 🔒 Boundary

Keeps privileged network evidence as a separate test-only proof surface and explicitly defers a public `action.yml` wrapper until Fence can truthfully implement protected readiness.
