### PR TITLE
Simplify CI check names

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -20,8 +20,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  packaged-public-contract:
-    name: packaged public contract
+  acceptance:
+    name: acceptance
     runs-on: ubuntu-24.04
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  package-linux-x64:
+  build:
     name: build
     runs-on: ubuntu-24.04
     env:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,4 +1,4 @@
-name: privileged-integration
+name: integration
 
 on:
   push:
@@ -20,8 +20,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  network-evidence:
-    name: privileged network evidence
+  integration:
+    name: integration
     runs-on: ubuntu-24.04
 
     steps:
@@ -39,5 +39,5 @@ jobs:
       - name: bootstrap
         run: script/bootstrap
 
-      - name: prove native network behavior in isolated namespaces
+      - name: test network evidence
         run: script/test-privileged

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,5 +67,5 @@ jobs:
       - name: bootstrap
         run: script/bootstrap
 
-      - name: coverage
+      - name: test with coverage
         run: script/test --coverage

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,13 +268,13 @@ If any version file changes, update docs and verify the corresponding script beh
 ## CI Expectations
 
 - The `build` workflow is the PR-based native Linux x64 package smoke test. It should validate locks, prepare Rust, run `script/bootstrap`, and run `script/build --release --targets "x86_64-unknown-linux-gnu"` on `ubuntu-24.04`.
-- The `acceptance` workflow should run only on `ubuntu-24.04`, build its own Linux x64 package from the current commit, verify its checksum, and invoke `script/test-package-smoke` as the `packaged public contract` check.
+- The `acceptance` workflow should run only on `ubuntu-24.04`, build its own Linux x64 package from the current commit, verify its checksum, and invoke `script/test-package-smoke` as the `acceptance` check.
 - The `build` workflow should exercise retained Zig/`cargo-zigbuild` artifacts in a distinct offline install/verify smoke job. That job is not a protected release artifact claim.
 - Hosted lint/test workflows may remain portable on fixed Ubuntu and macOS labels while their behavior is platform-neutral. Protected integration, package, and release jobs target fixed `ubuntu-24.04` x64 only.
 - Hosted lint/test/build workflows should run `script/validate-locks --ci`, then `script/prepare-rust`, then `script/bootstrap`, then their offline validation command or native package-smoke path.
 - Hosted coverage workflows should run `script/validate-locks --ci`, then `script/prepare-rust`, then `script/install-test-tools`, then `script/bootstrap`, then `script/test --coverage`.
-- The `privileged-integration` workflow should run only on `ubuntu-24.04`, prepare the pinned Rust toolchain through repository scripts, and invoke `script/test-privileged` for namespace-isolated `network_enforcement_test_only` evidence.
-- `acceptance` and `privileged-integration` must remain separate evidence boundaries: the former exercises the packaged non-enforcing CLI, while the latter proves privileged kernel/network behavior in disposable namespaces.
+- The `integration` workflow should run only on `ubuntu-24.04`, prepare the pinned Rust toolchain through repository scripts, and invoke `script/test-privileged` for namespace-isolated `network_enforcement_test_only` evidence.
+- `acceptance` and `integration` must remain separate evidence boundaries: the former exercises the packaged non-enforcing CLI, while the latter proves privileged kernel/network behavior in disposable namespaces.
 - Hosted validation should rely on offline defaults from `script/env` after explicit preparation completes.
 - Do not add Rust toolchain setup actions to hosted lint/test/build workflows; use `script/prepare-rust` so the preparation path stays explicit, checksum-gated, and repo-owned.
 - The first publishable agent release build job should run on `ubuntu-24.04`, run `script/validate-locks --ci`, then `script/prepare-rust`, then `script/bootstrap`, then `script/build --release --targets "x86_64-unknown-linux-gnu"`.
@@ -322,7 +322,7 @@ Tests are a design requirement for Fence.
 - Use integration tests for IO and process behavior, but do not substitute a few broad end-to-end tests for meaningful unit coverage.
 - The default first-party target is 100% line, function, and region coverage through `script/test --coverage`.
 - Document explicit coverage exceptions in the change that introduces them. Acceptable exceptions are narrow: unreachable defensive code, platform-specific code not runnable on the current CI host, generated code, or behavior proven by a separate higher-fidelity test harness.
-- `src/nft_backend.rs` and `src/nflog.rs` are explicit Phase 2 exceptions: their privileged execution, kernel-state, and netlink-socket failure paths are validated by `privileged-integration`, while deterministic normalization and prefix-to-metadata logic retain ordinary unit tests.
+- `src/nft_backend.rs` and `src/nflog.rs` are explicit Phase 2 exceptions: their privileged execution, kernel-state, and netlink-socket failure paths are validated by `integration`, while deterministic normalization and prefix-to-metadata logic retain ordinary unit tests.
 - Do not enable branch coverage with `cargo-llvm-cov` until that support is stable. Region coverage is the stable high-granularity gate for now.
 - Do not add `cargo-tarpaulin` or another coverage tool just because it is locally installed; `cargo-llvm-cov` is the repo-owned coverage path.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![test](https://github.com/GrantBirki/fence/actions/workflows/test.yml/badge.svg)](https://github.com/GrantBirki/fence/actions/workflows/test.yml)
 [![build](https://github.com/GrantBirki/fence/actions/workflows/build.yml/badge.svg)](https://github.com/GrantBirki/fence/actions/workflows/build.yml)
 [![acceptance](https://github.com/GrantBirki/fence/actions/workflows/acceptance.yml/badge.svg)](https://github.com/GrantBirki/fence/actions/workflows/acceptance.yml)
-[![privileged-integration](https://github.com/GrantBirki/fence/actions/workflows/privileged-integration.yml/badge.svg)](https://github.com/GrantBirki/fence/actions/workflows/privileged-integration.yml)
+[![integration](https://github.com/GrantBirki/fence/actions/workflows/integration.yml/badge.svg)](https://github.com/GrantBirki/fence/actions/workflows/integration.yml)
 
 Fence is an early-stage, source-auditable Rust project for hardening supported
 CI runners against undeclared outbound network access and ordinary

--- a/docs/repository-settings.md
+++ b/docs/repository-settings.md
@@ -11,8 +11,8 @@ Some security controls cannot be fully represented in tracked files. Configure t
   - `coverage`
   - `lint (macos-14)`
   - `lint (ubuntu-24.04)`
-  - `packaged public contract`
-  - `privileged network evidence`
+  - `acceptance`
+  - `integration`
   - `test (macos-14)`
   - `test (ubuntu-24.04)`
 - Require branches to be up to date before merging if that matches the repository's merge policy.
@@ -32,7 +32,7 @@ Some security controls cannot be fully represented in tracked files. Configure t
 - Protected package and release jobs should run only on GitHub-hosted `ubuntu-24.04` x64 and publish only the `x86_64-unknown-linux-gnu` agent artifact until an additional protected target is implemented and tested.
 - Keep the `build` workflow as the PR-based Linux x64 package smoke test: validate locks, prepare Rust, bootstrap, then run native release-mode packaging.
 - Keep the `acceptance` workflow as the distinct Linux x64 packaged public-contract gate: independently package the current commit, verify its checksum, then execute `script/test-package-smoke`.
-- Keep the `privileged-integration` workflow required as the distinct namespace-isolated native network-evidence gate; it does not assert public protection.
+- Keep the `integration` workflow required as the distinct namespace-isolated native network-evidence gate; it does not assert public protection.
 - Exercise retained Zig/`cargo-zigbuild` inputs through a separate offline installation/verification smoke job; those inputs are reserved for future cross-platform investigation and are not current release artifacts.
 - Do not add a public root `action.yml` before the protected lifecycle exists. A later wrapper should remain in this repository and be consumed externally only through an immutable reference.
 - If an egress-blocking action is added, apply it to build/test/package jobs after checkout and before scripts run. Do not apply it to release publishing, signing, or verification jobs unless those jobs are split into an explicitly GitHub-network-allowed phase.

--- a/docs/v0.md
+++ b/docs/v0.md
@@ -932,7 +932,7 @@ non-enforcing planner is healthy and hermetic:
 - no workflow presents macOS or ARM binaries as protected Fence agent
   releases.
 
-### Privileged integration workflow
+### Integration workflow
 
 Phase 2C privileged network evidence runs separately and only on the supported
 `ubuntu-24.04` x64 hosted environment. It must:


### PR DESCRIPTION
## 🧹 Summary

Renames the Phase 2 CI surfaces to the concise `acceptance` and `integration` check names, including the workflow filename and matching public and maintainer documentation.

## 🔒 Boundary

Keeps the evidence split unchanged: `acceptance` tests the packaged non-enforcing CLI, while `integration` runs the namespace-isolated privileged proof.
