### PR TITLE
Start Phase 3 hosted runner fingerprint gate

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,6 +33,9 @@ jobs:
       - name: validate locks
         run: script/validate-locks --ci
 
+      - name: observe hosted runner fingerprint candidate
+        run: script/observe-hosted-runner
+
       - name: prepare rust
         run: script/prepare-rust
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This repository is the Rust implementation scaffold for Fence, a security agent 
 
 Fence must pass the "airplane test": a normal developer or CI worker should be able to build, test, lint, and package the project without reaching the network after dependencies and toolchains have been explicitly prepared.
 
-The current Phase 3A binary is still non-enforcing: `render-plan` emits a deterministic native `nftables` preview, `check-support` exposes a pending hosted-runner fingerprint gate, and `run` fails closed without writing readiness or claiming protection. No first-party runtime path reaches native apply/verify/rollback or NFLOG ingestion; the repository exercises those paths only through privileged evidence tests. The integration workflow now collects bounded read-only hosted-runner observations so a later reviewed change can pin the single supported runner shape. The complete protected lifecycle and any public GitHub Action wrapper are later reviewed changes.
+The current Phase 3A binary is still non-enforcing: `render-plan` emits a deterministic native `nftables` preview, `check-support` exposes an accepted but not runtime-checked hosted-runner fingerprint reference, and `run` fails closed without writing readiness or claiming protection. No first-party runtime path reaches native apply/verify/rollback or NFLOG ingestion; the repository exercises those paths only through privileged evidence tests. The integration workflow collects bounded read-only hosted-runner observations for the single pinned runner shape. The complete protected lifecycle and any public GitHub Action wrapper are later reviewed changes.
 
 ## North-Star Principles
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This repository is the Rust implementation scaffold for Fence, a security agent 
 
 Fence must pass the "airplane test": a normal developer or CI worker should be able to build, test, lint, and package the project without reaching the network after dependencies and toolchains have been explicitly prepared.
 
-The current Phase 2C binary is still non-enforcing: `render-plan` emits a deterministic native `nftables` preview, while `run` fails closed and no code writes readiness or claims protection. No first-party runtime path reaches native apply/verify/rollback or NFLOG ingestion; the repository exercises those paths only through privileged evidence tests. A separate packaged-artifact acceptance test executes the distributed CLI shape without claiming protection. The complete protected lifecycle and any public GitHub Action wrapper are later reviewed changes.
+The current Phase 3A binary is still non-enforcing: `render-plan` emits a deterministic native `nftables` preview, `check-support` exposes a pending hosted-runner fingerprint gate, and `run` fails closed without writing readiness or claiming protection. No first-party runtime path reaches native apply/verify/rollback or NFLOG ingestion; the repository exercises those paths only through privileged evidence tests. The integration workflow now collects bounded read-only hosted-runner observations so a later reviewed change can pin the single supported runner shape. The complete protected lifecycle and any public GitHub Action wrapper are later reviewed changes.
 
 ## North-Star Principles
 
@@ -126,11 +126,17 @@ All scripts live in `script/` and should use `set -euo pipefail` unless there is
   - NFLOG handling may inspect at most the configured 64-byte packet prefix transiently in memory and must serialize approved endpoint metadata only.
   - Must not invoke the public `run` command, create a readiness file, mutate host firewall rules, or make a protection claim.
 
+- `script/observe-hosted-runner`
+  - Linux x64-only, read-only hosted-runner fingerprint candidate collector for the `integration` workflow.
+  - Emits bounded JSON describing only the runner principal/group names, fixed security-relevant paths, fixed systemd unit state, fixed runtime socket state, aggregate Docker workload count, and sudo-policy source digests plus `NOPASSWD` marker classification for review.
+  - Must not emit sudo policy contents, environment values, process arguments, workload identifiers, credentials, or arbitrary host files.
+  - Must not establish support, mutate host state, enable public enforcement, or write readiness.
+
 - `script/test-package-smoke`
   - Linux x64-only offline packaged-artifact acceptance entrypoint; it accepts exactly one already-built Fence binary path.
   - Uses only a literal-IP/CIDR policy fixture and Python standard-library JSON parsing; it must not resolve hostnames, install tools, or use network access.
   - Verifies versioned JSON output, deterministic `render-plan`, fail-closed `run`, no `inet fence_v0` table creation, and no `/run/fence/package-acceptance/` state creation.
-  - Proves only the Phase 2 public CLI contract of a packaged binary; it is distinct from privileged network evidence and cannot make a protection claim.
+  - Proves only the current non-enforcing public CLI contract of a packaged binary; it is distinct from hosted-runner observation and privileged network evidence and cannot make a protection claim.
 
 - `script/lint`
   - Runs format check, clippy, `cargo verify-project`, and docs.
@@ -273,8 +279,8 @@ If any version file changes, update docs and verify the corresponding script beh
 - Hosted lint/test workflows may remain portable on fixed Ubuntu and macOS labels while their behavior is platform-neutral. Protected integration, package, and release jobs target fixed `ubuntu-24.04` x64 only.
 - Hosted lint/test/build workflows should run `script/validate-locks --ci`, then `script/prepare-rust`, then `script/bootstrap`, then their offline validation command or native package-smoke path.
 - Hosted coverage workflows should run `script/validate-locks --ci`, then `script/prepare-rust`, then `script/install-test-tools`, then `script/bootstrap`, then `script/test --coverage`.
-- The `integration` workflow should run only on `ubuntu-24.04`, prepare the pinned Rust toolchain through repository scripts, and invoke `script/test-privileged` for namespace-isolated `network_enforcement_test_only` evidence.
-- `acceptance` and `integration` must remain separate evidence boundaries: the former exercises the packaged non-enforcing CLI, while the latter proves privileged kernel/network behavior in disposable namespaces.
+- The `integration` workflow should run only on `ubuntu-24.04`, prepare the pinned Rust toolchain through repository scripts, invoke `script/observe-hosted-runner` for bounded read-only runner-shape evidence, and invoke `script/test-privileged` for namespace-isolated `network_enforcement_test_only` evidence.
+- `acceptance` and `integration` must remain separate evidence boundaries: the former exercises the packaged non-enforcing CLI, while the latter observes the hosted shape and proves privileged kernel/network behavior without activating protection.
 - Hosted validation should rely on offline defaults from `script/env` after explicit preparation completes.
 - Do not add Rust toolchain setup actions to hosted lint/test/build workflows; use `script/prepare-rust` so the preparation path stays explicit, checksum-gated, and repo-owned.
 - The first publishable agent release build job should run on `ubuntu-24.04`, run `script/validate-locks --ci`, then `script/prepare-rust`, then `script/bootstrap`, then `script/build --release --targets "x86_64-unknown-linux-gnu"`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,7 +128,7 @@ All scripts live in `script/` and should use `set -euo pipefail` unless there is
 
 - `script/observe-hosted-runner`
   - Linux x64-only, read-only hosted-runner fingerprint candidate collector for the `integration` workflow.
-  - Emits bounded JSON describing only the runner principal/group names, fixed security-relevant paths, fixed systemd unit state, fixed runtime socket state, aggregate Docker workload count, and sudo-policy source digests plus `NOPASSWD` marker classification for review.
+  - Emits bounded JSON describing only the runner principal/group names, fixed security-relevant paths, fixed systemd unit state, fixed runtime socket state, aggregate Docker workload count, and sudo-policy source digests plus reduced principal/group `NOPASSWD` marker classification for review.
   - Must not emit sudo policy contents, environment values, process arguments, workload identifiers, credentials, or arbitrary host files.
   - Must not establish support, mutate host state, enable public enforcement, or write readiness.
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ CI runners against undeclared outbound network access and ordinary
 runner-privilege bypass paths. The intended first enforcement target is a
 GitHub-hosted `ubuntu-24.04` x64 runner executing a native Linux GNU binary.
 
-Fence is not an enforcement agent yet. The current Phase 2C executable strictly
-validates local JSON policy, renders a frozen policy and deterministic native
-`nftables` ruleset preview, and reports read-only host support observations. It
-never applies a network boundary, changes privilege state, writes readiness, or
-reports protection as available.
+Fence is not an enforcement agent yet. The current Phase 3A executable builds
+on the Phase 2 network-evidence backend: it strictly validates local JSON
+policy, renders a frozen policy and deterministic native `nftables` ruleset
+preview, and reports the pending hosted-runner fingerprint gate needed before
+the privileged lifecycle can be activated. It never applies a network
+boundary, changes privilege state, writes readiness, or reports protection as
+available.
 
 Phase 2C additionally exercises native apply, verification, rollback,
 forwarded-path behavior, and bounded NFLOG connection findings in disposable
@@ -25,9 +27,10 @@ raw packet bytes to evidence. This is test-only proof, not a usable protection
 mode.
 
 Pull requests also build a Linux x64 package independently and execute that
-artifact through the Phase 2 JSON CLI contract. This proves the distributed
-binary remains non-enforcing and fail-closed; it is not a public GitHub Action
-or a protection claim.
+artifact through the non-enforcing JSON CLI contract. The `integration`
+workflow additionally records a bounded, read-only hosted-runner fingerprint
+candidate before its existing namespace evidence tests. These checks do not
+establish public protection or create a GitHub Action interface.
 
 Read [docs/v0.md](docs/v0.md) for the normative v0 security boundary,
 interfaces, proof requirements, and implementation roadmap.
@@ -133,14 +136,16 @@ CI additionally runs `script/validate-locks --ci` and
 runners are not fully air-gapped: checkout, action loading, Rust preparation,
 artifact operations, and release publication still require network access.
 On `ubuntu-24.04`, `script/test-package-smoke` verifies the built Linux
-artifact's public non-enforcing contract separately from the privileged
-namespace evidence workflow.
+artifact's public non-enforcing contract separately from
+`script/observe-hosted-runner` and the privileged namespace evidence workflow.
 
-## Phase 2 CLI
+## Phase 3A CLI
 
 The current binary emits versioned JSON only. `render-plan` includes the fixed
 `inet fence_v0` ruleset preview, policy hash schema version `2`, and a ruleset
-hash. `run` fails closed until the privileged lifecycle is implemented.
+hash. `check-support` reports a versioned hosted-runner fingerprint gate as
+pending hosted review. `run` fails closed until the privileged lifecycle is
+implemented and proved.
 
 ```console
 script/build
@@ -151,13 +156,14 @@ script/build
 ```
 
 The last command intentionally returns an `enforcement_not_implemented` error
-through Phase 2. Do not use this planner or its ruleset preview as a runner
-security control.
+through the Phase 3 evidence-only slices. Do not use this planner or its
+ruleset preview as a runner security control.
 
 A public GitHub Action wrapper is deferred until a later protected lifecycle
-can truthfully establish readiness. That future wrapper is intended to live
-in this repository and carry a reviewed Linux binary in an immutable action
-reference; Phase 2 does not publish an `action.yml` interface or download an
+can truthfully establish readiness and an attested alpha agent has been
+published. That future wrapper is intended to live in this repository and
+carry the reviewed Linux release binary in an immutable action reference; the
+current project does not publish an `action.yml` interface or download an
 agent at workflow runtime.
 
 ## Release Baseline

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ GitHub-hosted `ubuntu-24.04` x64 runner executing a native Linux GNU binary.
 Fence is not an enforcement agent yet. The current Phase 3A executable builds
 on the Phase 2 network-evidence backend: it strictly validates local JSON
 policy, renders a frozen policy and deterministic native `nftables` ruleset
-preview, and reports the pending hosted-runner fingerprint gate needed before
-the privileged lifecycle can be activated. It never applies a network
-boundary, changes privilege state, writes readiness, or reports protection as
-available.
+preview, and reports an accepted but not runtime-checked hosted-runner
+fingerprint reference needed before the privileged lifecycle can be activated.
+It never applies a network boundary, changes privilege state, writes
+readiness, or reports protection as available.
 
 Phase 2C additionally exercises native apply, verification, rollback,
 forwarded-path behavior, and bounded NFLOG connection findings in disposable
@@ -144,8 +144,8 @@ artifact's public non-enforcing contract separately from
 The current binary emits versioned JSON only. `render-plan` includes the fixed
 `inet fence_v0` ruleset preview, policy hash schema version `2`, and a ruleset
 hash. `check-support` reports a versioned hosted-runner fingerprint gate as
-pending hosted review. `run` fails closed until the privileged lifecycle is
-implemented and proved.
+an accepted reference that is not yet checked or enforced by public execution.
+`run` fails closed until the privileged lifecycle is implemented and proved.
 
 ```console
 script/build

--- a/docs/repository-settings.md
+++ b/docs/repository-settings.md
@@ -32,7 +32,7 @@ Some security controls cannot be fully represented in tracked files. Configure t
 - Protected package and release jobs should run only on GitHub-hosted `ubuntu-24.04` x64 and publish only the `x86_64-unknown-linux-gnu` agent artifact until an additional protected target is implemented and tested.
 - Keep the `build` workflow as the PR-based Linux x64 package smoke test: validate locks, prepare Rust, bootstrap, then run native release-mode packaging.
 - Keep the `acceptance` workflow as the distinct Linux x64 packaged public-contract gate: independently package the current commit, verify its checksum, then execute `script/test-package-smoke`.
-- Keep the `integration` workflow required as the distinct namespace-isolated native network-evidence gate; it does not assert public protection.
+- Keep the `integration` workflow required as the distinct hosted-runner observation and namespace-isolated native network-evidence gate; its fingerprint candidate output is read-only and it does not assert public protection.
 - Exercise retained Zig/`cargo-zigbuild` inputs through a separate offline installation/verification smoke job; those inputs are reserved for future cross-platform investigation and are not current release artifacts.
 - Do not add a public root `action.yml` before the protected lifecycle exists. A later wrapper should remain in this repository and be consumed externally only through an immutable reference.
 - If an egress-blocking action is added, apply it to build/test/package jobs after checkout and before scripts run. Do not apply it to release publishing, signing, or verification jobs unless those jobs are split into an explicitly GitHub-network-allowed phase.

--- a/docs/v0.md
+++ b/docs/v0.md
@@ -14,7 +14,7 @@ design record for the v0 implementation.
 Fence is not an enforcement agent today. The current Phase 3A repository
 contains a hermetic Rust CLI that validates and freezes policy, renders a
 deterministic native `nftables` ruleset preview, and exposes a versioned
-hosted-runner fingerprint gate with status `observation_pending`. It does not
+hosted-runner fingerprint reference with status `accepted_reference_not_checked`. It does not
 apply that preview, write readiness, or establish a protection boundary. A
 packaged planning binary is not a security control. The Phase 2C backend also
 executes native network-policy and bounded NFLOG finding proof in disposable
@@ -375,9 +375,9 @@ been applied or verified.
 Successful `check-support` data additionally contains
 `hosted_runner_fingerprint` with schema version `1`, the fixed intended
 protected target, the observation method, and a status. Phase 3A exposes
-`observation_pending` until a reviewed `ubuntu-24.04` integration observation
-has pinned the single supported host shape. A pending or matched fingerprint
-is not evidence that protection is active.
+`accepted_reference_not_checked` after a reviewed `ubuntu-24.04` integration
+observation pins the single supported host shape. An accepted but unchecked
+fingerprint is not evidence that protection is active.
 
 ### Strict JSON only
 
@@ -770,6 +770,21 @@ workload identifiers, arbitrary host files, credentials, or payload data.
 Observation output remains `observation_only_no_protection`. Before the
 resident lifecycle is implemented and proved, `check-support` must continue
 to emit `protection_available: false` and `run` must remain fail-closed.
+
+The accepted Phase 3A reference records:
+
+| Surface | Accepted observed shape |
+| --- | --- |
+| Host identity | Ubuntu `24.04`, `x86_64`, principal `runner` |
+| Required group consequence | The principal is a member of `docker`, providing access to the Docker socket before lockdown |
+| Required executable paths | `/usr/bin/docker`, `/usr/bin/systemctl`, `/usr/bin/systemd-run`, `/usr/sbin/nft` |
+| Passwordless sudo classification | The `runner` sudo drop-in is the sole observed policy source with a direct runner-applicable `NOPASSWD` marker |
+| Container activation paths | `docker.service`, `docker.socket`, and `containerd.service` are loaded and active; `containerd.socket` is not present |
+| Container sockets | Docker sockets are root-owned with `docker` group access; the containerd socket is root-owned with `root` group access |
+| Existing Docker workload count | Zero at observation time |
+
+This accepted reference is a design input only. Runtime support comparison,
+lockdown, and readiness remain unimplemented until later Phase 3 slices.
 
 ### Transient root service
 
@@ -1167,8 +1182,9 @@ branch; the wrapper must not download an agent or policy at workflow runtime.
 On `ubuntu-24.04` x64, the packaged public-contract workflow must prove:
 
 - the Linux x64 GNU package checksum verifies before the artifact is executed;
-- `--version` and `check-support` emit JSON that reports Phase 3A, a pending
-  hosted-runner fingerprint gate, and no protection availability;
+- `--version` and `check-support` emit JSON that reports Phase 3A, an accepted
+  but unchecked hosted-runner fingerprint reference, and no protection
+  availability;
 - two literal-policy `render-plan` executions are byte-identical and report
   policy-hash schema version `2`, native `inet fence_v0` preview constants,
   and `not_applied` / `not_verified` status;

--- a/docs/v0.md
+++ b/docs/v0.md
@@ -11,16 +11,18 @@ an outbound-network and ordinary privilege-bypass boundary for a narrowly
 supported GitHub-hosted Linux runner. This document is the single normative
 design record for the v0 implementation.
 
-Fence is not an enforcement agent today. The repository currently contains a
-hermetic Rust CLI that validates and freezes policy, renders a deterministic
-native `nftables` ruleset preview, and reports read-only capability
-observations. It does not apply that preview, write readiness, or establish a
-protection boundary. A packaged planning binary is not a security control.
-Phase 2C also executes native network-policy and bounded NFLOG finding proof
-in disposable privileged test namespaces; this evidence is not reachable from
-the public CLI. A distinct packaged-artifact acceptance path executes the
-Linux x64 binary through its public Phase 2 JSON contract and proves that it
-remains non-enforcing; it does not create a GitHub Action interface.
+Fence is not an enforcement agent today. The current Phase 3A repository
+contains a hermetic Rust CLI that validates and freezes policy, renders a
+deterministic native `nftables` ruleset preview, and exposes a versioned
+hosted-runner fingerprint gate with status `observation_pending`. It does not
+apply that preview, write readiness, or establish a protection boundary. A
+packaged planning binary is not a security control. The Phase 2C backend also
+executes native network-policy and bounded NFLOG finding proof in disposable
+privileged test namespaces; this evidence is not reachable from the public
+CLI. A distinct packaged-artifact acceptance path executes the Linux x64
+binary through its current non-enforcing JSON contract, while the integration
+path records a bounded read-only hosted-runner fingerprint candidate. Neither
+path creates a GitHub Action interface or protection claim.
 
 The first protected release is deliberately narrow:
 
@@ -308,6 +310,11 @@ After readiness:
 The protected runner is ephemeral. Teardown of the runner, not a privileged
 post-job restore path, ends enforcement.
 
+The initial protected lifecycle must re-verify owned network, sudo-lockdown,
+and container-lockdown state on a fixed five-second local interval. A
+verification failure after readiness is evidence of critical drift; it is not
+permission to restore or silently weaken policy.
+
 ### Post-ready verification failures
 
 Until a later wrapper has a proved mechanism to propagate a late background
@@ -340,21 +347,21 @@ Command behavior:
 | Command | Purpose | Security-state mutation |
 | --- | --- | --- |
 | `--version` | Identify binary build/version metadata. | None |
-| `check-support` | Inspect host identity and native-backend presence read-only, while emitting that protection remains unavailable. | None |
+| `check-support` | Inspect host identity and native-backend presence read-only, and report the hosted-runner fingerprint gate while emitting that protection remains unavailable. | None |
 | `render-plan --config` | Validate JSON, resolve hostnames under bounds, and render the exact frozen policy plus native-ruleset preview. | None |
-| `run --config` | Through Phase 2, fail closed without reading configuration; in the later protected lifecycle, execute selected-mode behavior from root-owned input. | None through Phase 2; yes when implemented |
+| `run --config` | Through Phase 3 evidence work, fail closed without reading configuration; in the later activated lifecycle, execute selected-mode behavior from root-owned input. | None until activation; yes when implemented and proved |
 
 There are no v0 commands to restore, unlock, disable, flush, update, or
 interactively administer a running agent.
 
-Phase 2 emits versioned JSON only. Successful command results are written to
+The current Phase 3A binary emits versioned JSON only. Successful command results are written to
 standard output; structured failures are written to standard error. The
 response envelope contains `schema_version`, `command`, `status`,
 `fence_version`, and exactly one of `data` or `error`. Command-shape failures
 exit `2`; policy, resolution, unsupported, and not-implemented failures exit
 `1`.
 
-In Phase 2A, successful `render-plan` data additionally contains:
+Successful `render-plan` data additionally contains:
 
 - `policy_hash_schema_version: 2` and `policy_hash` for normalized logical
   policy, including fixed implicit IPv6 control rules;
@@ -364,6 +371,13 @@ In Phase 2A, successful `render-plan` data additionally contains:
 
 These values are planning evidence only. They do not show that any rule has
 been applied or verified.
+
+Successful `check-support` data additionally contains
+`hosted_runner_fingerprint` with schema version `1`, the fixed intended
+protected target, the observation method, and a status. Phase 3A exposes
+`observation_pending` until a reviewed `ubuntu-24.04` integration observation
+has pinned the single supported host shape. A pending or matched fingerprint
+is not evidence that protection is active.
 
 ### Strict JSON only
 
@@ -411,7 +425,7 @@ Top-level fields:
 | `schema_version` | Required integer; v0 accepts exactly `1`. |
 | `mode` | Required enum: `"block"` or `"audit"`; omission is invalid. |
 | `invocation_id` | Required reportable non-secret slug: 1 through 64 lowercase ASCII letters or digits with internal hyphens only, used for reports and derived runtime paths, not kernel object identifiers. |
-| `platform_profile` | Phase 2 accepts omission or `"none"` and normalizes both to no profile; named profile identifiers are unavailable until a profile is proved. |
+| `platform_profile` | Pre-activation phases accept omission or `"none"` and normalize both to no profile; named profile identifiers are unavailable until a profile is proved. |
 | `container_policy` | For `block`, omitted means `"disable"` and `"unsafe_preserve"` is explicit degraded behavior; `audit` cannot request protection-bearing lockdown. |
 | `allowances` | Required array; it may be empty to declare zero user egress. |
 
@@ -734,6 +748,29 @@ reports active observation.
 
 ## Privilege And Container Controls
 
+### Hosted runner fingerprint gate
+
+Fence v0 supports one measured GitHub-hosted `ubuntu-24.04` x64 runner shape,
+not a generalized Linux-host mutation strategy. Phase 3A adds a read-only
+`script/observe-hosted-runner` integration step to produce a candidate for
+review before any lifecycle mutation can be implemented.
+
+The observation is limited to the facts required to design lockdown:
+
+- OS and architecture plus the expected runner principal and group names;
+- presence of fixed native `nft`, `systemd-run`, `systemctl`, and Docker paths;
+- state of fixed Docker/containerd service and socket unit names;
+- metadata for fixed Docker/containerd socket paths;
+- an aggregate count of existing Docker workloads; and
+- names, SHA-256 digests, and `NOPASSWD` marker classifications of sudo
+  policy source files for subsequent source classification.
+
+It does not emit sudo policy text, environment values, process arguments,
+workload identifiers, arbitrary host files, credentials, or payload data.
+Observation output remains `observation_only_no_protection`. Before the
+resident lifecycle is implemented and proved, `check-support` must continue
+to emit `protection_available: false` and `run` must remain fail-closed.
+
 ### Transient root service
 
 The security-critical agent runs as a root-owned transient `systemd` service.
@@ -765,8 +802,11 @@ inject command syntax, or select arbitrary filesystem destinations.
 Protected block mode removes ordinary passwordless-sudo ability after network
 policy has been applied and verified. The implementation must:
 
-- detect the expected Ubuntu 24.04 hosted-runner configuration;
-- mutate only explicitly supported and reviewed sudo state;
+- match the reviewed hosted-runner fingerprint before mutation;
+- relocate only the measured passwordless-sudo drop-in source or sources into
+  root-only provisional storage;
+- fail unsupported if passwordless access originates from a broader or
+  unclassified source instead of editing unknown policy;
 - fail before ready if lockdown cannot be established;
 - verify that an unprivileged `sudo -n true` attempt cannot succeed; and
 - never restore broad sudo access after readiness.
@@ -778,8 +818,11 @@ bypass.
 
 For protected block mode with `container_policy: "disable"`, Fence must remove
 ordinary Docker/containerd control paths that would let later workflow code
-regain host-equivalent authority. The exact supported image mutation and
-verification steps are selected through hosted-runner tests, but must cover:
+regain host-equivalent authority. For the single accepted hosted fingerprint,
+the implementation must fail if unexpected existing workloads are observed,
+stop and runtime-mask the measured Docker/containerd socket and service
+activation paths, and verify daemon and socket access is unavailable. Tests
+must cover:
 
 - present runtime services and their activation paths;
 - present sockets and runner-user access to them;
@@ -787,7 +830,8 @@ verification steps are selected through hosted-runner tests, but must cover:
 - any network path that exists before lockdown completes.
 
 If required container lockdown cannot be verified, protected block mode fails
-before readiness.
+before readiness. Fence v0 does not adaptively mutate unrecognized runtime
+layouts; image drift is an unsupported-host result requiring review.
 
 For `container_policy: "unsafe_preserve"`, Fence does not make the ordinary
 containment assertion. It must expose degraded assurance prominently in both
@@ -861,13 +905,14 @@ includes:
 - SHA-pinned GitHub Actions; and
 - script-first local and CI validation entrypoints.
 
-The current Phase 2C Rust CLI implements strict JSON parsing, deterministic
+The current Phase 3A Rust CLI implements strict JSON parsing, deterministic
 policy and native-ruleset preview generation, typed expected-state
-verification modeling, and read-only support reporting only. It proves this
-modeling surface but does not implement an enforcement boundary. No public
-command or other first-party runtime path invokes the internal backend;
-privileged integration tests exercise native apply, read, verify, rollback,
-and bounded NFLOG conversion operations and write evidence status
+verification modeling, pending hosted-runner fingerprint reporting, and
+read-only support reporting only. It proves these modeling and observation
+surfaces but does not implement an enforcement boundary. No public command or
+other first-party runtime path invokes the internal backend; privileged
+integration tests exercise native apply, read, verify, rollback, and bounded
+NFLOG conversion operations and write evidence status
 `network_enforcement_test_only` without a readiness file.
 
 ### Offline and online boundaries
@@ -934,8 +979,10 @@ non-enforcing planner is healthy and hermetic:
 
 ### Integration workflow
 
-Phase 2C privileged network evidence runs separately and only on the supported
-`ubuntu-24.04` x64 hosted environment. It must:
+The `integration` workflow runs separately and only on the intended
+`ubuntu-24.04` x64 hosted environment. In Phase 3A it first runs
+`script/observe-hosted-runner` to generate bounded read-only fingerprint
+candidate evidence. Its existing Phase 2C privileged network tests must:
 
 - use disposable network namespaces rather than installing host deny rules;
 - prove dual-stack native nftables block and audit behavior;
@@ -948,11 +995,12 @@ Phase 2C privileged network evidence runs separately and only on the supported
 
 Later Phase 3 and Phase 4 privileged tests add sudo/container lockdown,
 no-restore lifecycle behavior, and measurement of any proposed platform
-finalization profile. Those protections are not Phase 2C claims.
+finalization profile. The observation candidate and native network tests do
+not by themselves establish protection.
 
 ### Packaged public-contract acceptance workflow
 
-Phase 2 packaged acceptance runs separately from privileged network evidence
+Packaged non-enforcing acceptance runs separately from privileged evidence
 and only on `ubuntu-24.04` x64. It must:
 
 - independently package the current commit as a Linux x64 GNU artifact and
@@ -1053,15 +1101,18 @@ is the required behavioral proof.
 
 ### Phase 3: Resident service and lockdown
 
-Implement:
+Phase 3 remains evidence-only until its final activation gate:
 
-- transient `systemd` service lifecycle;
-- Ubuntu 24.04 x64 supported-image checks;
-- protected block-mode passwordless-sudo lockdown;
-- protected block-mode Docker/containerd lockdown;
-- explicit degraded `unsafe_preserve` behavior;
-- readiness ordering and no-restore behavior; and
-- resident state verification with critical local findings.
+1. Phase 3A introduces the versioned hosted-runner fingerprint gate, runs a
+   bounded read-only observation in hosted integration, and pins exactly one
+   reviewed `ubuntu-24.04` x64 host shape.
+2. Phase 3B implements secure root-owned runtime state, transient `systemd`
+   supervision, resident NFLOG/report handling, readiness ordering, five-second
+   verification, and pre-ready rollback behind privileged tests only.
+3. Phase 3C implements and proves the narrow sudo-drop-in and
+   Docker/containerd stop-and-runtime-mask lockdown strategy, including
+   `unsafe_preserve` and audit behavior, while public `run` remains
+   fail-closed.
 
 ### Phase 4: Hosted proof and compatibility decision
 
@@ -1075,20 +1126,23 @@ Exercise controlled hosted workflows to:
 - select either a versioned default profile with `"none"` escape or no
   built-in profile.
 
+After those gates pass, activate public `run` only for a root-owned transient
+service invocation on the pinned host shape. Direct or unsupported invocation
+must fail before mutation.
+
 ### Phase 5: Proven alpha release
 
-Publish only a Linux x64 GNU prerelease after all release gates are met.
+Publish only a Linux x64 GNU `0.1.0-alpha.1` prerelease after all release gates are met.
 Artifact publication must remain source-built, checksum-verified, and
-attestation-verified. An action wrapper is a subsequent user-facing layer,
-not a prerequisite for proving the agent binary's first local boundary.
+attestation-verified.
 
-A future Action wrapper belongs in this repository at the root so repository
-acceptance can exercise it with `uses: ./`. It is deferred until a protected
-lifecycle can truthfully report readiness. External documentation must use an
-immutable commit SHA or intentionally managed immutable release tag, not a
-floating branch; the wrapper must carry its reviewed Linux binary in that
-immutable source reference and must not download an agent or policy at
-workflow runtime.
+After that attested agent exists, add the Action wrapper in this repository at
+the root so repository acceptance can exercise it with `uses: ./`. The wrapper
+uses dependency-free JavaScript entry and post steps, accepts one bounded
+inline strict-JSON configuration input, and carries an exact copy of the
+reviewed Linux release binary plus provenance manifest. External
+documentation must use an immutable commit SHA initially, not a floating
+branch; the wrapper must not download an agent or policy at workflow runtime.
 
 ## Test Requirements
 
@@ -1108,13 +1162,13 @@ workflow runtime.
 - Hermetic lock validation and existing scaffold test/lint/build/coverage
   scripts still pass.
 
-### Packaged Phase 2 CLI acceptance tests
+### Packaged Non-Enforcing CLI Acceptance Tests
 
 On `ubuntu-24.04` x64, the packaged public-contract workflow must prove:
 
 - the Linux x64 GNU package checksum verifies before the artifact is executed;
-- `--version` and `check-support` emit JSON that reports Phase 2 and no
-  protection availability;
+- `--version` and `check-support` emit JSON that reports Phase 3A, a pending
+  hosted-runner fingerprint gate, and no protection availability;
 - two literal-policy `render-plan` executions are byte-identical and report
   policy-hash schema version `2`, native `inet fence_v0` preview constants,
   and `not_applied` / `not_verified` status;

--- a/docs/v0.md
+++ b/docs/v0.md
@@ -762,8 +762,8 @@ The observation is limited to the facts required to design lockdown:
 - state of fixed Docker/containerd service and socket unit names;
 - metadata for fixed Docker/containerd socket paths;
 - an aggregate count of existing Docker workloads; and
-- names, SHA-256 digests, and `NOPASSWD` marker classifications of sudo
-  policy source files for subsequent source classification.
+- names, SHA-256 digests, and reduced direct-principal or runner-group
+  `NOPASSWD` marker classifications of sudo policy sources.
 
 It does not emit sudo policy text, environment values, process arguments,
 workload identifiers, arbitrary host files, credentials, or payload data.

--- a/script/observe-hosted-runner
+++ b/script/observe-hosted-runner
@@ -71,7 +71,23 @@ def command_output(args):
     return result.stdout[:4096]
 
 
-def regular_file_hash(path):
+def runner_nopasswd_markers(contents, principal, groups):
+    text = contents.decode("utf-8", errors="ignore").replace("\\\n", " ")
+    accepted_subjects = {principal: "principal"}
+    accepted_subjects.update({f"%{group}": "group" for group in groups})
+    markers = []
+    for original_line in text.splitlines():
+        line = original_line.split("#", 1)[0].strip()
+        if "NOPASSWD:" not in line:
+            continue
+        subject = line.split(None, 1)[0] if line else ""
+        marker = accepted_subjects.get(subject)
+        if marker is not None and marker not in markers:
+            markers.append(marker)
+    return sorted(markers)
+
+
+def regular_file_observation(path, principal, groups):
     candidate = pathlib.Path(path)
     if not candidate.is_file() or candidate.is_symlink():
         return None
@@ -83,6 +99,7 @@ def regular_file_hash(path):
         "name": candidate.name,
         "sha256": digest,
         "contains_nopasswd_directive": b"NOPASSWD:" in contents,
+        "runner_nopasswd_markers": runner_nopasswd_markers(contents, principal, groups),
     }
 
 
@@ -158,15 +175,16 @@ def principal_groups(principal):
     return values[:64]
 
 
+runner_groups = principal_groups(sys.argv[1])
 sudo_sources = []
-main_sudoers = regular_file_hash("/etc/sudoers")
+main_sudoers = regular_file_observation("/etc/sudoers", sys.argv[1], runner_groups)
 if main_sudoers is not None:
     main_sudoers["path_class"] = "main_policy"
     sudo_sources.append(main_sudoers)
 drop_in_root = pathlib.Path("/etc/sudoers.d")
 if drop_in_root.is_dir():
     for candidate in sorted(drop_in_root.iterdir()):
-        hashed = regular_file_hash(candidate)
+        hashed = regular_file_observation(candidate, sys.argv[1], runner_groups)
         if hashed is not None:
             hashed["path_class"] = "drop_in"
             sudo_sources.append(hashed)
@@ -195,7 +213,7 @@ result = {
         "os_version_id": os_identity["version_id"],
         "architecture": platform.machine(),
         "runner_principal": sys.argv[1],
-        "runner_groups": principal_groups(sys.argv[1]),
+        "runner_groups": runner_groups,
     },
     "required_paths": [
         {"path": path, "executable": os.access(path, os.X_OK)} for path in FIXED_PATHS

--- a/script/observe-hosted-runner
+++ b/script/observe-hosted-runner
@@ -1,0 +1,216 @@
+#! /usr/bin/env bash
+
+set -euo pipefail
+
+source script/env "$@"
+
+if [[ $# -ne 0 ]]; then
+  die "usage: script/observe-hosted-runner"
+fi
+
+require_cmd sudo
+require_cmd python3
+
+if [[ "$PLATFORM" != "linux" || "$ARCH" != "x86_64" ]]; then
+  die "hosted-runner observation requires Linux x86_64"
+fi
+
+runner_principal="$(/usr/bin/id -un)"
+if ! [[ "$runner_principal" =~ ^[a-z_][a-z0-9_-]{0,31}$ ]]; then
+  die "hosted-runner observation encountered an invalid caller principal"
+fi
+
+# Observe only fixed security-relevant surfaces. Do not emit file contents,
+# environment values, process arguments, workload identifiers, or socket data.
+sudo --non-interactive /usr/bin/python3 - "$runner_principal" <<'PY'
+import grp
+import hashlib
+import json
+import os
+import pathlib
+import platform
+import pwd
+import stat
+import subprocess
+import sys
+
+MAX_POLICY_SOURCE_BYTES = 256 * 1024
+FIXED_PATHS = [
+    "/usr/bin/docker",
+    "/usr/bin/systemctl",
+    "/usr/bin/systemd-run",
+    "/usr/sbin/nft",
+]
+FIXED_UNITS = [
+    "docker.service",
+    "docker.socket",
+    "containerd.service",
+    "containerd.socket",
+]
+FIXED_SOCKETS = [
+    "/var/run/docker.sock",
+    "/run/docker.sock",
+    "/run/containerd/containerd.sock",
+]
+
+
+def command_output(args):
+    try:
+        result = subprocess.run(
+            args,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            env={"LANG": "C", "LC_ALL": "C", "PATH": "/usr/bin:/usr/sbin:/bin:/sbin"},
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode not in (0, 1, 3, 4):
+        return None
+    return result.stdout[:4096]
+
+
+def regular_file_hash(path):
+    candidate = pathlib.Path(path)
+    if not candidate.is_file() or candidate.is_symlink():
+        return None
+    if candidate.stat().st_size > MAX_POLICY_SOURCE_BYTES:
+        return {"name": candidate.name, "status": "oversized"}
+    contents = candidate.read_bytes()
+    digest = hashlib.sha256(contents).hexdigest()
+    return {
+        "name": candidate.name,
+        "sha256": digest,
+        "contains_nopasswd_directive": b"NOPASSWD:" in contents,
+    }
+
+
+def unit_state(unit):
+    output = command_output(
+        [
+            "/usr/bin/systemctl",
+            "show",
+            "--no-pager",
+            "--property=LoadState",
+            "--property=ActiveState",
+            "--property=UnitFileState",
+            unit,
+        ]
+    )
+    values = {
+        "name": unit,
+        "load_state": "unobserved",
+        "active_state": "unobserved",
+        "unit_file_state": "unobserved",
+    }
+    if output is not None:
+        for line in output.splitlines():
+            key, _, value = line.partition("=")
+            output_key = {
+                "LoadState": "load_state",
+                "ActiveState": "active_state",
+                "UnitFileState": "unit_file_state",
+            }.get(key)
+            if output_key is not None:
+                values[output_key] = value[:64]
+    return values
+
+
+def socket_state(path):
+    candidate = pathlib.Path(path)
+    try:
+        metadata = candidate.stat()
+    except FileNotFoundError:
+        return {"path": path, "present": False}
+    mode = stat.S_IMODE(metadata.st_mode)
+    kind = "socket" if stat.S_ISSOCK(metadata.st_mode) else "unexpected_type"
+    try:
+        owner = pwd.getpwuid(metadata.st_uid).pw_name
+    except KeyError:
+        owner = str(metadata.st_uid)
+    try:
+        group = grp.getgrgid(metadata.st_gid).gr_name
+    except KeyError:
+        group = str(metadata.st_gid)
+    return {
+        "path": path,
+        "present": True,
+        "type": kind,
+        "mode": format(mode, "04o"),
+        "owner": owner[:64],
+        "group": group[:64],
+    }
+
+
+def principal_groups(principal):
+    try:
+        primary = pwd.getpwnam(principal).pw_gid
+        identifiers = os.getgrouplist(principal, primary)
+    except KeyError:
+        return []
+    values = []
+    for identifier in sorted(set(identifiers)):
+        try:
+            values.append(grp.getgrgid(identifier).gr_name[:64])
+        except KeyError:
+            values.append(str(identifier))
+    return values[:64]
+
+
+sudo_sources = []
+main_sudoers = regular_file_hash("/etc/sudoers")
+if main_sudoers is not None:
+    main_sudoers["path_class"] = "main_policy"
+    sudo_sources.append(main_sudoers)
+drop_in_root = pathlib.Path("/etc/sudoers.d")
+if drop_in_root.is_dir():
+    for candidate in sorted(drop_in_root.iterdir()):
+        hashed = regular_file_hash(candidate)
+        if hashed is not None:
+            hashed["path_class"] = "drop_in"
+            sudo_sources.append(hashed)
+
+docker_ps = command_output(["/usr/bin/docker", "ps", "--quiet"])
+docker_workload_count = (
+    None if docker_ps is None else len([line for line in docker_ps.splitlines() if line])
+)
+
+os_identity = {"id": "unknown", "version_id": "unknown"}
+try:
+    for line in pathlib.Path("/etc/os-release").read_text(encoding="utf-8").splitlines():
+        key, _, value = line.partition("=")
+        if key in {"ID", "VERSION_ID"}:
+            os_identity[key.lower()] = value.strip().strip('"')[:64]
+except (FileNotFoundError, UnicodeDecodeError):
+    pass
+
+result = {
+    "schema_version": 1,
+    "observation": "hosted_runner_fingerprint_candidate",
+    "status": "observation_only_no_protection",
+    "protected_target": "github_hosted_ubuntu_24_04_x86_64",
+    "host": {
+        "os_id": os_identity["id"],
+        "os_version_id": os_identity["version_id"],
+        "architecture": platform.machine(),
+        "runner_principal": sys.argv[1],
+        "runner_groups": principal_groups(sys.argv[1]),
+    },
+    "required_paths": [
+        {"path": path, "executable": os.access(path, os.X_OK)} for path in FIXED_PATHS
+    ],
+    "systemd": {"units": [unit_state(unit) for unit in FIXED_UNITS]},
+    "sudo": {
+        "noninteractive_root_observation_succeeded": True,
+        "policy_source_hashes": sudo_sources,
+        "grant_source_review_required": True,
+    },
+    "container_runtime": {
+        "sockets": [socket_state(path) for path in FIXED_SOCKETS],
+        "docker_running_workload_count": docker_workload_count,
+    },
+    "next_step": "review_and_pin_supported_fingerprint_before_lifecycle_mutation",
+}
+print(json.dumps(result, sort_keys=True, separators=(",", ":")))
+PY

--- a/script/test-package-smoke
+++ b/script/test-package-smoke
@@ -144,7 +144,7 @@ require(
     "support omitted public-enforcement reason",
 )
 require(
-    "hosted_runner_fingerprint_pending" in data["reasons"],
+    "hosted_runner_fingerprint_not_checked" in data["reasons"],
     "support omitted fingerprint reason",
 )
 require("lockdown_not_implemented" in data["reasons"], "support omitted lockdown reason")
@@ -158,7 +158,19 @@ require(
 )
 require(data["network_backend"]["nft_binary_present"] is True, "support omitted nft binary")
 require(data["hosted_runner_fingerprint"]["schema_version"] == 1, "support fingerprint schema mismatch")
-require(data["hosted_runner_fingerprint"]["status"] == "observation_pending", "support fingerprint status mismatch")
+require(data["hosted_runner_fingerprint"]["status"] == "accepted_reference_not_checked", "support fingerprint status mismatch")
+require(
+    data["hosted_runner_fingerprint"]["accepted"]["expected_principal"] == "runner",
+    "support fingerprint principal mismatch",
+)
+require(
+    any(
+        source["name"] == "runner"
+        and source["runner_nopasswd_markers"] == ["principal"]
+        for source in data["hosted_runner_fingerprint"]["accepted"]["sudo_policy_sources"]
+    ),
+    "support fingerprint did not classify the runner sudo source",
+)
 PY
 
 capture_command plan-first render-plan --config "$fixture"

--- a/script/test-package-smoke
+++ b/script/test-package-smoke
@@ -56,7 +56,7 @@ PY
 
 assert_no_runtime_state() {
   if [[ -e "$runtime_directory" ]]; then
-    die "public Phase 2 command unexpectedly created runtime state: $runtime_directory"
+    die "public non-enforcing command unexpectedly created runtime state: $runtime_directory"
   fi
 }
 
@@ -113,7 +113,7 @@ require(result["schema_version"] == 1, "version response schema mismatch")
 require(result["command"] == "version", "version command field mismatch")
 require(result["status"] == "success", "version response status mismatch")
 require(result["fence_version"] == "0.0.0", "version envelope version mismatch")
-require(result["data"]["implementation_phase"] == "phase2", "version phase mismatch")
+require(result["data"]["implementation_phase"] == "phase3", "version phase mismatch")
 require(result["data"]["protection_available"] is False, "version reported protection")
 PY
 
@@ -136,12 +136,16 @@ require(result["schema_version"] == 1, "support response schema mismatch")
 require(result["command"] == "check-support", "support command field mismatch")
 require(result["status"] == "success", "support response status mismatch")
 require(result["fence_version"] == "0.0.0", "support envelope version mismatch")
-require(data["implementation_phase"] == "phase2", "support phase mismatch")
+require(data["implementation_phase"] == "phase3", "support phase mismatch")
 require(data["intended_protected_target_match"] is True, "support target mismatch")
 require(data["protection_available"] is False, "support reported protection")
 require(
     "public_enforcement_not_activated" in data["reasons"],
     "support omitted public-enforcement reason",
+)
+require(
+    "hosted_runner_fingerprint_pending" in data["reasons"],
+    "support omitted fingerprint reason",
 )
 require("lockdown_not_implemented" in data["reasons"], "support omitted lockdown reason")
 require(
@@ -153,6 +157,8 @@ require(
     "support nft path mismatch",
 )
 require(data["network_backend"]["nft_binary_present"] is True, "support omitted nft binary")
+require(data["hosted_runner_fingerprint"]["schema_version"] == 1, "support fingerprint schema mismatch")
+require(data["hosted_runner_fingerprint"]["status"] == "observation_pending", "support fingerprint status mismatch")
 PY
 
 capture_command plan-first render-plan --config "$fixture"
@@ -180,7 +186,7 @@ require(result["schema_version"] == 1, "plan response schema mismatch")
 require(result["command"] == "render-plan", "plan command field mismatch")
 require(result["status"] == "success", "plan response status mismatch")
 require(result["fence_version"] == "0.0.0", "plan envelope version mismatch")
-require(data["implementation_phase"] == "phase2", "plan phase mismatch")
+require(data["implementation_phase"] == "phase3", "plan phase mismatch")
 require(data["policy_hash_schema_version"] == 2, "plan policy hash schema mismatch")
 require(re.fullmatch(r"[0-9a-f]{64}", data["policy_hash"]), "invalid policy hash")
 require(re.fullmatch(r"[0-9a-f]{64}", data["ruleset_hash"]), "invalid ruleset hash")
@@ -233,4 +239,4 @@ fi
 assert_no_owned_table after
 assert_no_runtime_state
 
-echo -e "${GREEN}packaged public Phase 2 CLI contract verified${OFF}"
+echo -e "${GREEN}packaged public non-enforcing CLI contract verified${OFF}"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,7 +12,7 @@ use std::path::PathBuf;
 #[derive(Debug, Parser)]
 #[command(
     name = "fence",
-    about = "Fence phase2 network-policy modeling agent",
+    about = "Fence phase3 hosted-runner lifecycle design agent",
     disable_help_flag = true,
     disable_version_flag = true
 )]
@@ -161,7 +161,7 @@ mod tests {
         let support = execute_test(&["fence", "check-support"]);
 
         assert_eq!(version.exit_code, 0);
-        assert!(version.json.contains("\"implementation_phase\":\"phase2\""));
+        assert!(version.json.contains("\"implementation_phase\":\"phase3\""));
         assert_eq!(support.exit_code, 0);
         assert!(support.json.contains("\"protection_available\":false"));
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -142,7 +142,7 @@ pub fn parse_and_normalize(bytes: &[u8]) -> Result<NormalizedConfig, ErrorDetail
     if input.platform_profile.as_deref().unwrap_or("none") != "none" {
         return Err(ErrorDetail::new(
             "invalid_platform_profile",
-            "only the none platform profile is available in phase2",
+            "only the none platform profile is available before hosted proof",
         )
         .field("platform_profile"));
     }
@@ -150,7 +150,7 @@ pub fn parse_and_normalize(bytes: &[u8]) -> Result<NormalizedConfig, ErrorDetail
     if input.allowances.len() > MAX_ALLOWANCES {
         return Err(ErrorDetail::new(
             "too_many_allowances",
-            "allowances exceeds the fixed phase2 limit",
+            "allowances exceeds the fixed v0 limit",
         )
         .field("allowances"));
     }

--- a/src/hosted_runner.rs
+++ b/src/hosted_runner.rs
@@ -8,26 +8,147 @@ pub struct HostedRunnerFingerprintV1 {
     pub protected_target: &'static str,
     pub status: &'static str,
     pub observation_method: &'static str,
-    pub accepted: Option<AcceptedHostedRunnerFactsV1>,
+    pub accepted: AcceptedHostedRunnerFactsV1,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize)]
 pub struct AcceptedHostedRunnerFactsV1 {
+    pub os_id: &'static str,
+    pub os_version_id: &'static str,
+    pub architecture: &'static str,
     pub expected_principal: &'static str,
-    pub nft_binary_path: &'static str,
-    pub systemd_run_path: &'static str,
-    pub sudo_grant_source_classification: &'static str,
-    pub container_activation_paths: Vec<&'static str>,
-    pub container_socket_paths: Vec<&'static str>,
+    pub required_runner_groups: Vec<&'static str>,
+    pub executable_paths: Vec<&'static str>,
+    pub sudo_policy_sources: Vec<AcceptedSudoPolicySourceV1>,
+    pub container_units: Vec<AcceptedUnitV1>,
+    pub container_sockets: Vec<AcceptedSocketV1>,
+    pub required_docker_running_workload_count: u32,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct AcceptedSudoPolicySourceV1 {
+    pub path_class: &'static str,
+    pub name: &'static str,
+    pub sha256: &'static str,
+    pub runner_nopasswd_markers: Vec<&'static str>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct AcceptedUnitV1 {
+    pub name: &'static str,
+    pub load_state: &'static str,
+    pub active_state: &'static str,
+    pub unit_file_state: &'static str,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct AcceptedSocketV1 {
+    pub path: &'static str,
+    pub present: bool,
+    pub kind: &'static str,
+    pub mode: &'static str,
+    pub owner: &'static str,
+    pub group: &'static str,
 }
 
 pub fn hosted_runner_fingerprint_requirement() -> HostedRunnerFingerprintV1 {
     HostedRunnerFingerprintV1 {
         schema_version: HOSTED_RUNNER_FINGERPRINT_SCHEMA_VERSION,
         protected_target: "github_hosted_ubuntu_24_04_x86_64",
-        status: "observation_pending",
+        status: "accepted_reference_not_checked",
         observation_method: "integration_read_only_observation",
-        accepted: None,
+        accepted: AcceptedHostedRunnerFactsV1 {
+            os_id: "ubuntu",
+            os_version_id: "24.04",
+            architecture: "x86_64",
+            expected_principal: "runner",
+            required_runner_groups: vec!["adm", "users", "docker", "systemd-journal", "runner"],
+            executable_paths: vec![
+                "/usr/bin/docker",
+                "/usr/bin/systemctl",
+                "/usr/bin/systemd-run",
+                "/usr/sbin/nft",
+            ],
+            sudo_policy_sources: vec![
+                AcceptedSudoPolicySourceV1 {
+                    path_class: "main_policy",
+                    name: "sudoers",
+                    sha256: "5bac27ce5ff1a78ace8f3ef81bfd60cbd44810ac3f3d280da9d7649fe90c18f8",
+                    runner_nopasswd_markers: vec![],
+                },
+                AcceptedSudoPolicySourceV1 {
+                    path_class: "drop_in",
+                    name: "90-cloud-init-users",
+                    sha256: "55b0a6eab1edea9a2151c9b73deff81fb365854a070045452766aa4a0397ab13",
+                    runner_nopasswd_markers: vec![],
+                },
+                AcceptedSudoPolicySourceV1 {
+                    path_class: "drop_in",
+                    name: "README",
+                    sha256: "b428c9b673c3c806370f2aa28a98293a9cb578c70c3a8a2d1a39031861b3dbd8",
+                    runner_nopasswd_markers: vec![],
+                },
+                AcceptedSudoPolicySourceV1 {
+                    path_class: "drop_in",
+                    name: "runner",
+                    sha256: "661b4f06df1e149cc4d88457270d9ce39d2597963042718fb0da9573398f8714",
+                    runner_nopasswd_markers: vec!["principal"],
+                },
+            ],
+            container_units: vec![
+                AcceptedUnitV1 {
+                    name: "docker.service",
+                    load_state: "loaded",
+                    active_state: "active",
+                    unit_file_state: "enabled",
+                },
+                AcceptedUnitV1 {
+                    name: "docker.socket",
+                    load_state: "loaded",
+                    active_state: "active",
+                    unit_file_state: "enabled",
+                },
+                AcceptedUnitV1 {
+                    name: "containerd.service",
+                    load_state: "loaded",
+                    active_state: "active",
+                    unit_file_state: "enabled",
+                },
+                AcceptedUnitV1 {
+                    name: "containerd.socket",
+                    load_state: "not-found",
+                    active_state: "inactive",
+                    unit_file_state: "",
+                },
+            ],
+            container_sockets: vec![
+                AcceptedSocketV1 {
+                    path: "/var/run/docker.sock",
+                    present: true,
+                    kind: "socket",
+                    mode: "0660",
+                    owner: "root",
+                    group: "docker",
+                },
+                AcceptedSocketV1 {
+                    path: "/run/docker.sock",
+                    present: true,
+                    kind: "socket",
+                    mode: "0660",
+                    owner: "root",
+                    group: "docker",
+                },
+                AcceptedSocketV1 {
+                    path: "/run/containerd/containerd.sock",
+                    present: true,
+                    kind: "socket",
+                    mode: "0660",
+                    owner: "root",
+                    group: "root",
+                },
+            ],
+            required_docker_running_workload_count: 0,
+        },
     }
 }
 
@@ -36,7 +157,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn fingerprint_stays_pending_until_hosted_evidence_is_reviewed() {
+    fn fingerprint_pins_the_reviewed_non_activated_hosted_reference() {
         let requirement = hosted_runner_fingerprint_requirement();
 
         assert_eq!(requirement.schema_version, 1);
@@ -44,7 +165,25 @@ mod tests {
             requirement.protected_target,
             "github_hosted_ubuntu_24_04_x86_64"
         );
-        assert_eq!(requirement.status, "observation_pending");
-        assert!(requirement.accepted.is_none());
+        assert_eq!(requirement.status, "accepted_reference_not_checked");
+        assert_eq!(requirement.accepted.expected_principal, "runner");
+        assert!(
+            requirement
+                .accepted
+                .required_runner_groups
+                .contains(&"docker")
+        );
+        assert_eq!(
+            requirement.accepted.sudo_policy_sources[3].runner_nopasswd_markers,
+            vec!["principal"]
+        );
+        assert_eq!(
+            requirement.accepted.container_units[0].name,
+            "docker.service"
+        );
+        assert_eq!(
+            requirement.accepted.required_docker_running_workload_count,
+            0
+        );
     }
 }

--- a/src/hosted_runner.rs
+++ b/src/hosted_runner.rs
@@ -1,0 +1,50 @@
+use serde::Serialize;
+
+pub const HOSTED_RUNNER_FINGERPRINT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct HostedRunnerFingerprintV1 {
+    pub schema_version: u32,
+    pub protected_target: &'static str,
+    pub status: &'static str,
+    pub observation_method: &'static str,
+    pub accepted: Option<AcceptedHostedRunnerFactsV1>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct AcceptedHostedRunnerFactsV1 {
+    pub expected_principal: &'static str,
+    pub nft_binary_path: &'static str,
+    pub systemd_run_path: &'static str,
+    pub sudo_grant_source_classification: &'static str,
+    pub container_activation_paths: Vec<&'static str>,
+    pub container_socket_paths: Vec<&'static str>,
+}
+
+pub fn hosted_runner_fingerprint_requirement() -> HostedRunnerFingerprintV1 {
+    HostedRunnerFingerprintV1 {
+        schema_version: HOSTED_RUNNER_FINGERPRINT_SCHEMA_VERSION,
+        protected_target: "github_hosted_ubuntu_24_04_x86_64",
+        status: "observation_pending",
+        observation_method: "integration_read_only_observation",
+        accepted: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fingerprint_stays_pending_until_hosted_evidence_is_reviewed() {
+        let requirement = hosted_runner_fingerprint_requirement();
+
+        assert_eq!(requirement.schema_version, 1);
+        assert_eq!(
+            requirement.protected_target,
+            "github_hosted_ubuntu_24_04_x86_64"
+        );
+        assert_eq!(requirement.status, "observation_pending");
+        assert!(requirement.accepted.is_none());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod cli;
 pub mod config;
 pub mod error;
 pub mod findings;
+pub mod hosted_runner;
 #[cfg(target_os = "linux")]
 #[doc(hidden)]
 pub mod nflog;
@@ -17,7 +18,7 @@ pub mod support;
 
 use serde::Serialize;
 
-pub const IMPLEMENTATION_PHASE: &str = "phase2";
+pub const IMPLEMENTATION_PHASE: &str = "phase3";
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize)]
 pub struct VersionInfo {
@@ -52,7 +53,7 @@ mod tests {
 
         assert_eq!(info.name, env!("CARGO_PKG_NAME"));
         assert_eq!(info.version, env!("CARGO_PKG_VERSION"));
-        assert_eq!(info.implementation_phase, "phase2");
+        assert_eq!(info.implementation_phase, "phase3");
         assert!(!info.protection_available);
     }
 }

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -271,7 +271,7 @@ fn assurance_status(mode: Mode, container_policy: Option<ContainerPolicy>) -> As
 }
 
 fn limitations(status: AssuranceStatus) -> Vec<&'static str> {
-    let mut limitations = vec!["phase2_network_model_only_no_public_enforcement"];
+    let mut limitations = vec!["phase3_lifecycle_not_activated_no_public_enforcement"];
     match status {
         AssuranceStatus::PlannedBlockContainment => {}
         AssuranceStatus::PlannedBlockDegradedContainerAccess => {

--- a/src/support.rs
+++ b/src/support.rs
@@ -1,3 +1,5 @@
+use crate::IMPLEMENTATION_PHASE;
+use crate::hosted_runner::{HostedRunnerFingerprintV1, hosted_runner_fingerprint_requirement};
 use serde::Serialize;
 use std::path::Path;
 
@@ -55,12 +57,13 @@ pub struct SupportData {
     pub reasons: Vec<&'static str>,
     pub deferred_capability_probes: Vec<&'static str>,
     pub network_backend: NetworkBackendObservation,
+    pub hosted_runner_fingerprint: HostedRunnerFingerprintV1,
 }
 
 pub fn inspect_support(provider: &dyn SupportProvider) -> SupportData {
     let identity = provider.host_identity();
     SupportData {
-        implementation_phase: "phase2",
+        implementation_phase: IMPLEMENTATION_PHASE,
         intended_protected_target_match: identity.os == "linux"
             && identity.architecture == "x86_64",
         host_os: identity.os,
@@ -68,6 +71,7 @@ pub fn inspect_support(provider: &dyn SupportProvider) -> SupportData {
         protection_available: false,
         reasons: vec![
             "public_enforcement_not_activated",
+            "hosted_runner_fingerprint_pending",
             "lockdown_not_implemented",
         ],
         deferred_capability_probes: vec![
@@ -76,6 +80,7 @@ pub fn inspect_support(provider: &dyn SupportProvider) -> SupportData {
             "container_lockdown",
         ],
         network_backend: provider.network_backend_observation(),
+        hosted_runner_fingerprint: hosted_runner_fingerprint_requirement(),
     }
 }
 
@@ -108,7 +113,7 @@ mod tests {
     }
 
     #[test]
-    fn intended_target_still_reports_no_protection_in_phase2() {
+    fn intended_target_still_reports_no_protection_in_phase3a() {
         let data = inspect_support(&FixedProvider {
             os: "linux",
             architecture: "x86_64",
@@ -120,10 +125,12 @@ mod tests {
             data.reasons,
             vec![
                 "public_enforcement_not_activated",
+                "hosted_runner_fingerprint_pending",
                 "lockdown_not_implemented"
             ]
         );
         assert!(data.network_backend.nft_binary_present);
+        assert_eq!(data.hosted_runner_fingerprint.status, "observation_pending");
     }
 
     #[test]

--- a/src/support.rs
+++ b/src/support.rs
@@ -71,7 +71,7 @@ pub fn inspect_support(provider: &dyn SupportProvider) -> SupportData {
         protection_available: false,
         reasons: vec![
             "public_enforcement_not_activated",
-            "hosted_runner_fingerprint_pending",
+            "hosted_runner_fingerprint_not_checked",
             "lockdown_not_implemented",
         ],
         deferred_capability_probes: vec![
@@ -125,12 +125,15 @@ mod tests {
             data.reasons,
             vec![
                 "public_enforcement_not_activated",
-                "hosted_runner_fingerprint_pending",
+                "hosted_runner_fingerprint_not_checked",
                 "lockdown_not_implemented"
             ]
         );
         assert!(data.network_backend.nft_binary_present);
-        assert_eq!(data.hosted_runner_fingerprint.status, "observation_pending");
+        assert_eq!(
+            data.hosted_runner_fingerprint.status,
+            "accepted_reference_not_checked"
+        );
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -43,7 +43,7 @@ fn version_is_json_and_does_not_claim_protection() {
 
     assert_eq!(response["command"], "version");
     assert_eq!(response["status"], "success");
-    assert_eq!(response["data"]["implementation_phase"], "phase2");
+    assert_eq!(response["data"]["implementation_phase"], "phase3");
     assert_eq!(response["data"]["protection_available"], false);
 }
 
@@ -52,7 +52,12 @@ fn support_is_read_only_and_not_protective() {
     let response = success_json(&["check-support"]);
 
     assert_eq!(response["command"], "check-support");
+    assert_eq!(response["data"]["implementation_phase"], "phase3");
     assert_eq!(response["data"]["protection_available"], false);
+    assert_eq!(
+        response["data"]["hosted_runner_fingerprint"]["status"],
+        "observation_pending"
+    );
     assert_eq!(
         response["data"]["reasons"][0],
         "public_enforcement_not_activated"

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -56,7 +56,11 @@ fn support_is_read_only_and_not_protective() {
     assert_eq!(response["data"]["protection_available"], false);
     assert_eq!(
         response["data"]["hosted_runner_fingerprint"]["status"],
-        "observation_pending"
+        "accepted_reference_not_checked"
+    );
+    assert_eq!(
+        response["data"]["hosted_runner_fingerprint"]["accepted"]["expected_principal"],
+        "runner"
     );
     assert_eq!(
         response["data"]["reasons"][0],


### PR DESCRIPTION
## 🔍 Summary

Adds the Phase 3A hosted-runner fingerprint gate and a bounded, read-only `ubuntu-24.04` observation step for `integration`.

## 🔒 Boundary

`fence run` remains fail-closed and `check-support` remains non-protecting. The reviewed reference pins the runner principal, relevant passwordless-sudo source classification, and Docker/containerd control surface for later lifecycle implementation.
