### PR TITLE
Publish v0.1.0-alpha.3 agent prerelease

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "fence"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "clap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fence"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 edition = "2024"
 rust-version = "1.95.0"
 


### PR DESCRIPTION
## 📦 Summary

Publish `v0.1.0-alpha.3` as the final Fence v0 prerelease candidate after dependency cleanup, profile narrowing, and runtime-evidence contract stabilization.

## 🔒 Scope

This PR changes only the package version and lockfile root entry. The bundled Action remains pinned to the previously attested `v0.1.0-alpha.2` binary until the new prerelease is published and verified.