### PR TITLE
Document immutable v0.1.2 Action pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ consumers should pin Fence to a full immutable commit SHA rather than a
 floating branch:
 
 ```yaml
-- uses: GrantBirki/fence@f087c7b2bab87701b5114ccf82261cdd80e96995
+- uses: GrantBirki/fence@eb175bb3c7d4b28007e01d2c26b93ea8df820e6f
 ```
 
 The zero-input form is the strict default: standard block mode, disabled
@@ -266,7 +266,7 @@ container control paths, the selected GitHub-hosted job-status profile, and no
 user-defined egress. Advanced configuration remains explicit:
 
 ```yaml
-- uses: GrantBirki/fence@f087c7b2bab87701b5114ccf82261cdd80e96995
+- uses: GrantBirki/fence@eb175bb3c7d4b28007e01d2c26b93ea8df820e6f
   with:
     config: >-
       {"schema_version":1,"mode":"block","invocation_id":"example-run","allowlist":[]}


### PR DESCRIPTION
## 📌 Summary

Update the public zero-input and advanced Fence Action examples to the immutable commit that carries the attested stable `v0.1.2` bundle.