### PR TITLE
Improve Fence Action summary UX

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,14 +188,14 @@ All scripts live in `script/` and should use `set -euo pipefail` unless there is
   - Must never become an Action runtime step.
 
 - `script/test-action-wrapper`
-  - Offline-only dependency-free TypeScript and Node built-in `node:test` checks for the Action launcher, report validation, critical-finding propagation, runtime-path derivation, and bundle checksum validation.
+  - Offline-only dependency-free TypeScript and Node built-in `node:test` checks for the Action launcher, report validation, concise job-summary rendering, audit allowlist guidance, critical-finding propagation, runtime-path derivation, and bundle checksum validation.
   - The wrapper uses Node 24 built-in type stripping and Node standard-library modules only. Do not add `npm`, `package.json`, `node_modules`, external Node packages, or a runtime compilation step.
   - Proves that an omitted Action input derives a bounded invocation identifier from GitHub run metadata and emits strict schema-`1` standard block with an empty `allowlist`; also proves `mode: audit` emits strict schema-`1` observation mode without requiring a raw JSON config.
   - The wrapper and hosted acceptance assertions require runtime-evidence schema `1` and stable profile-realization fields.
 
 - `script/test-action-acceptance`
   - Linux x64-only, GitHub-Actions-only hosted acceptance entrypoint invoked after `uses: ./`.
-  - Proves standard block, degraded `unsafe_preserve`, and audit behavior from the bundled release binary while controls remain resident until ephemeral teardown.
+  - Proves standard block, degraded `unsafe_preserve`, and audit behavior from the bundled release binary while controls remain resident until ephemeral teardown. Audit acceptance also exercises a non-profile public hostname so the Action summary has DNS-backed would-block evidence to turn into `allowlist` guidance.
   - Must not stop the service, restore controls, download an agent, or fetch policy.
 
 - `script/test-action-setup-failure`

--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ Advanced callers may provide an explicit strict JSON configuration:
    Docker/containerd control paths before emitting readiness.
 4. The agent remains resident, records bounded local evidence, and checks for
    policy drift. Fence never restores access after readiness.
-5. The Action post hook renders a bounded summary and fails the job when
-   critical resident findings are present.
+5. The Action post hook renders a concise Fence Summary, including audit-mode
+   would-block guidance when available, and fails the job when critical
+   resident findings are present.
 
 ## Modes 🎛️
 

--- a/action/lib.cts
+++ b/action/lib.cts
@@ -2,6 +2,7 @@
 
 const crypto = require("node:crypto");
 const fs = require("node:fs");
+const net = require("node:net");
 const path = require("node:path");
 
 type Environment = Record<string, string | undefined>;
@@ -10,6 +11,7 @@ type RuntimePaths = {
   config: string;
   ready: string;
   report: string;
+  dnsReport: string;
   unit: string;
 };
 type InlineConfig = {
@@ -18,10 +20,29 @@ type InlineConfig = {
   usingDefault: boolean;
 };
 type DefaultMode = "block" | "audit";
+type AuditFindingRow = {
+  destination: string;
+  destinationKind: "hostname" | "ip";
+  protocol: string;
+  port: number;
+  count: number;
+};
+type AuditSummary = {
+  dnsMissing: boolean;
+  hostnameRows: AuditFindingRow[];
+  ipRows: AuditFindingRow[];
+  omittedHostnameRows: number;
+  omittedIpRows: number;
+  unparsedCount: number;
+  sourceTruncated: boolean;
+};
 
 const MAX_CONFIG_BYTES = 256 * 1024;
 const MAX_REPORT_BYTES = 4 * 1024 * 1024;
+const MAX_AUDIT_HOSTNAME_ROWS = 10;
+const MAX_AUDIT_IP_ROWS = 10;
 const INVOCATION_ID = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const DNS_HOSTNAME = /^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)*[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
 const PROFILE_REALIZATIONS = new Map([
   ["github_hosted_workflow_bootstrap_v1", "github_hosted_workflow_bootstrap_dns_mediation_v1"],
 ]);
@@ -122,6 +143,7 @@ function runtimePaths(invocationId: unknown): RuntimePaths {
     config: path.join(directory, "config.json"),
     ready: path.join(directory, "ready.json"),
     report: path.join(directory, "report.json"),
+    dnsReport: path.join(directory, "dns-report.json"),
     unit: `fence-${invocationId}.service`,
   };
 }
@@ -201,7 +223,9 @@ function validateReport(report: any, failOnCritical = true): any {
     fail("Fence report contains critical resident findings");
   }
   if (report.network_verification_status !== "verified") {
-    fail("Fence report does not contain verified network state");
+    if (failOnCritical || report.critical_findings.length === 0) {
+      fail("Fence report does not contain verified network state");
+    }
   }
   const expected = {
     protected_host_block: {
@@ -272,31 +296,308 @@ function boundedScalar(value: unknown): string {
   return String(value).replace(/[^A-Za-z0-9_.:-]/g, "_").slice(0, 96);
 }
 
-function summaryLines(report: any): string[] {
-  return [
-    "### Fence local evidence",
+function boundedText(value: unknown, maximum = 192): string {
+  if (typeof value !== "string" && typeof value !== "number" && typeof value !== "boolean") {
+    return "unavailable";
+  }
+  return String(value)
+    .replace(/[\r\n]+/g, " ")
+    .replace(/\|/g, "\\|")
+    .slice(0, maximum);
+}
+
+function markdownCode(value: unknown, maximum = 128): string {
+  return `\`${boundedText(value, maximum).replace(/`/g, "_")}\``;
+}
+
+function isSafeHostname(value: unknown): value is string {
+  return typeof value === "string" &&
+    value === value.toLowerCase() &&
+    !value.includes("*") &&
+    !value.endsWith(".") &&
+    DNS_HOSTNAME.test(value);
+}
+
+function isSupportedProtocol(value: unknown): value is string {
+  return value === "tcp" || value === "udp";
+}
+
+function isValidPort(value: unknown): value is number {
+  return Number.isInteger(value) && value >= 1 && value <= 65535;
+}
+
+function addRow(rows: Map<string, AuditFindingRow>, row: Omit<AuditFindingRow, "count">): void {
+  const key = `${row.destinationKind}\0${row.destination}\0${row.protocol}\0${row.port}`;
+  const existing = rows.get(key);
+  if (existing) {
+    existing.count += 1;
+  } else {
+    rows.set(key, { ...row, count: 1 });
+  }
+}
+
+function sortedRows(rows: Iterable<AuditFindingRow>): AuditFindingRow[] {
+  return Array.from(rows).sort((left, right) =>
+    right.count - left.count ||
+    left.destination.localeCompare(right.destination) ||
+    left.protocol.localeCompare(right.protocol) ||
+    left.port - right.port
+  );
+}
+
+function dnsAddressHostnameMap(dnsEvidence: any): Map<string, Set<string>> {
+  const addressMap = new Map<string, Set<string>>();
+  if (dnsEvidence === undefined || dnsEvidence === null || !Array.isArray(dnsEvidence.observations)) {
+    return addressMap;
+  }
+  for (const observation of dnsEvidence.observations) {
+    if (observation === null || Array.isArray(observation) || typeof observation !== "object") {
+      continue;
+    }
+    if (observation.query_type !== "a" && observation.query_type !== "aaaa") {
+      continue;
+    }
+    const hostname = observation.hostname;
+    if (!isSafeHostname(hostname) || !Array.isArray(observation.resolved_addresses)) {
+      continue;
+    }
+    for (const address of observation.resolved_addresses) {
+      if (typeof address !== "string" || net.isIP(address) === 0) {
+        continue;
+      }
+      const hostnames = addressMap.get(address) || new Set<string>();
+      hostnames.add(hostname);
+      addressMap.set(address, hostnames);
+    }
+  }
+  return addressMap;
+}
+
+function correlateFindingsToDns(report: any, dnsEvidence: any = undefined): AuditSummary {
+  const hostnameRows = new Map<string, AuditFindingRow>();
+  const ipRows = new Map<string, AuditFindingRow>();
+  const addressMap = dnsAddressHostnameMap(dnsEvidence);
+  let unparsedCount = 0;
+
+  for (const finding of Array.isArray(report.findings) ? report.findings : []) {
+    if (
+      finding === null ||
+      Array.isArray(finding) ||
+      typeof finding !== "object" ||
+      finding.classification !== "would_block"
+    ) {
+      continue;
+    }
+    if (
+      typeof finding.remote_address !== "string" ||
+      net.isIP(finding.remote_address) === 0 ||
+      !isSupportedProtocol(finding.protocol) ||
+      !isValidPort(finding.remote_port)
+    ) {
+      unparsedCount += 1;
+      continue;
+    }
+
+    const hostnames = Array.from(addressMap.get(finding.remote_address) || []).sort();
+    if (hostnames.length > 0) {
+      for (const hostname of hostnames) {
+        addRow(hostnameRows, {
+          destination: hostname,
+          destinationKind: "hostname",
+          protocol: finding.protocol,
+          port: finding.remote_port,
+        });
+      }
+    } else {
+      addRow(ipRows, {
+        destination: finding.remote_address,
+        destinationKind: "ip",
+        protocol: finding.protocol,
+        port: finding.remote_port,
+      });
+    }
+  }
+
+  const allHostnameRows = sortedRows(hostnameRows.values());
+  const allIpRows = sortedRows(ipRows.values());
+  return {
+    dnsMissing: dnsEvidence === undefined || dnsEvidence === null,
+    hostnameRows: allHostnameRows.slice(0, MAX_AUDIT_HOSTNAME_ROWS),
+    ipRows: allIpRows.slice(0, MAX_AUDIT_IP_ROWS),
+    omittedHostnameRows: Math.max(0, allHostnameRows.length - MAX_AUDIT_HOSTNAME_ROWS),
+    omittedIpRows: Math.max(0, allIpRows.length - MAX_AUDIT_IP_ROWS),
+    unparsedCount,
+    sourceTruncated: report.findings_truncated === true ||
+      Boolean(dnsEvidence && dnsEvidence.observations_truncated === true),
+  };
+}
+
+function summaryHeading(summaryState: { healthy: boolean }): string {
+  return summaryState.healthy ? "### 🟢 Fence Summary" : "### Fence Summary";
+}
+
+function summaryHasWarnings(report: any, auditSummary: AuditSummary): boolean {
+  return (
+    report.status === "protected_host_block_degraded" ||
+    report.network_verification_status !== "verified" ||
+    (Array.isArray(report.critical_findings) && report.critical_findings.length > 0) ||
+    report.critical_findings_truncated === true ||
+    report.findings_truncated === true ||
+    auditSummary.sourceTruncated ||
+    auditSummary.omittedHostnameRows > 0 ||
+    auditSummary.omittedIpRows > 0 ||
+    (report.mode === "audit" && auditSummary.dnsMissing)
+  );
+}
+
+function criticalFindingLines(report: any): string[] {
+  if (!Array.isArray(report.critical_findings) || report.critical_findings.length === 0) {
+    return [];
+  }
+  const lines = [
     "",
-    "| Field | Value |",
+    "| Finding | Detail |",
     "| --- | --- |",
-    `| status | \`${boundedScalar(report.status)}\` |`,
-    `| mode | \`${boundedScalar(report.mode)}\` |`,
-    `| readiness | \`${boundedScalar(report.readiness_status)}\` |`,
-    `| network verification | \`${boundedScalar(report.network_verification_status)}\` |`,
-    `| sudo | \`${boundedScalar(report.sudo_status)}\` |`,
-    `| containers | \`${boundedScalar(report.container_status)}\` |`,
-    `| platform profile | \`${boundedScalar(report.platform_profile_id)}\` |`,
-    `| critical findings | \`${report.critical_findings.length}\` |`,
+  ];
+  for (const finding of report.critical_findings.slice(0, 5)) {
+    lines.push(`| ${markdownCode(finding && finding.code)} | ${boundedText(finding && finding.message)} |`);
+  }
+  if (report.critical_findings.length > 5) {
+    lines.push(`| ${markdownCode("additional_findings_omitted")} | ${report.critical_findings.length - 5} more critical findings are available in the local report. |`);
+  }
+  return lines;
+}
+
+function modeStatusCard(report: any): string[] {
+  if (
+    report.network_verification_status !== "verified" ||
+    (Array.isArray(report.critical_findings) && report.critical_findings.length > 0)
+  ) {
+    return [
+      "**Fence needs attention**",
+      "",
+      "Fence detected a critical issue after startup and marked this job as failed.",
+      ...criticalFindingLines(report),
+    ];
+  }
+
+  if (report.status === "protected_host_block_degraded") {
+    return [
+      "**Limited assurance**",
+      "",
+      "Fence limited outbound traffic and locked down passwordless sudo, but Docker/container access was preserved. Container access can bypass the ordinary containment claim.",
+    ];
+  }
+
+  if (report.mode === "audit") {
+    return [
+      "**Observing only**",
+      "",
+      "Fence did not block traffic in audit mode. The destinations below would need review before switching this workflow to block mode.",
+    ];
+  }
+
+  return [
+    "**Network restrictions active**",
     "",
-    "Fence remains resident until ephemeral runner teardown. This summary does not restore access.",
+    "Fence limited outbound traffic to the GitHub workflow support channel and your `allowlist`. Passwordless sudo and Docker/container access were locked down. Controls remain active until the runner is torn down.",
+  ];
+}
+
+function allowlistYamlSnippet(rows: AuditFindingRow[]): string[] {
+  if (rows.length === 0) {
+    return [];
+  }
+  const allowlist = rows.map((row) => ({
+    destination_type: "hostname",
+    destination: row.destination,
+    protocol: row.protocol,
+    port: row.port,
+  }));
+  const config = JSON.stringify({
+    schema_version: 1,
+    mode: "block",
+    invocation_id: "example-run",
+    allowlist,
+  }, null, 2);
+
+  return [
+    "",
+    "<details>",
+    "<summary>View allowlist example</summary>",
+    "",
+    "```yaml",
+    "- uses: GrantBirki/fence@<commit-sha>",
+    "  with:",
+    "    config: >-",
+    ...config.split("\n").map((line) => `      ${line}`),
+    "```",
+    "",
+    "</details>",
+  ];
+}
+
+function auditWouldBlockSummary(report: any, dnsEvidence: any = undefined, auditSummary: AuditSummary = correlateFindingsToDns(report, dnsEvidence)): string[] {
+  if (report.mode !== "audit") {
+    return [];
+  }
+
+  const rows = [...auditSummary.hostnameRows, ...auditSummary.ipRows];
+  const lines = ["", "#### Would Be Blocked In Block Mode", ""];
+  if (auditSummary.dnsMissing) {
+    lines.push("DNS audit evidence was unavailable, so Fence could only report IP-level findings.", "");
+  }
+  if (rows.length === 0 && auditSummary.unparsedCount === 0) {
+    lines.push("No would-block destinations were observed during this audit run.");
+    return lines;
+  }
+
+  if (rows.length > 0) {
+    lines.push("| Destination | Protocol | Port | Count |");
+    lines.push("| --- | --- | ---: | ---: |");
+    for (const row of rows) {
+      lines.push(`| ${markdownCode(row.destination)} | ${markdownCode(row.protocol)} | ${markdownCode(row.port)} | ${markdownCode(row.count)} |`);
+    }
+    lines.push("");
+  }
+  if (auditSummary.ipRows.length > 0 && auditSummary.hostnameRows.length === 0) {
+    lines.push("Manual review required for IP-only findings.");
+    lines.push("");
+  }
+  if (auditSummary.unparsedCount > 0) {
+    lines.push(`${auditSummary.unparsedCount} would-block finding(s) could not be mapped to an endpoint from the bounded packet prefix.`);
+    lines.push("");
+  }
+  if (auditSummary.sourceTruncated || auditSummary.omittedHostnameRows > 0 || auditSummary.omittedIpRows > 0) {
+    const omitted = auditSummary.omittedHostnameRows + auditSummary.omittedIpRows;
+    lines.push(`Some audit evidence was truncated or omitted from this summary. Review the local report for full bounded evidence${omitted > 0 ? `; ${omitted} grouped row(s) were omitted here` : ""}.`);
+  }
+  lines.push(...allowlistYamlSnippet(auditSummary.hostnameRows));
+  return lines;
+}
+
+function summaryLines(report: any, dnsEvidence: any = undefined): string[] {
+  const auditSummary = correlateFindingsToDns(report, dnsEvidence);
+  const summaryState = { healthy: !summaryHasWarnings(report, auditSummary) };
+  return [
+    summaryHeading(summaryState),
+    "",
+    ...modeStatusCard(report),
+    ...auditWouldBlockSummary(report, dnsEvidence, auditSummary),
     "",
   ];
 }
 
 module.exports = {
   MAX_REPORT_BYTES,
+  allowlistYamlSnippet,
+  auditWouldBlockSummary,
+  correlateFindingsToDns,
   defaultInlineConfig,
+  modeStatusCard,
   readJsonBounded,
   runtimePaths,
+  summaryHeading,
   summaryLines,
   validateBundle,
   validateInlineConfig,

--- a/action/main.cts
+++ b/action/main.cts
@@ -7,7 +7,6 @@ const {
   MAX_REPORT_BYTES,
   readJsonBounded,
   runtimePaths,
-  summaryLines,
   validateBundle,
   validateInlineConfig,
   validateReady,
@@ -75,14 +74,6 @@ function appendState(name: string, value: string): void {
   fs.appendFileSync(state, `${name}=${value}\n`, { encoding: "utf8" });
 }
 
-function appendSummary(report: any): void {
-  if (process.env.GITHUB_STEP_SUMMARY) {
-    fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, summaryLines(report).join("\n"), {
-      encoding: "utf8",
-    });
-  }
-}
-
 function waitForReady(paths: { ready: string; report: string }): any {
   const deadline = Date.now() + READY_TIMEOUT_MS;
   while (Date.now() < deadline) {
@@ -119,6 +110,7 @@ function main(): void {
 
   appendState("invocation_id", config.invocationId);
   appendState("report_path", paths.report);
+  appendState("dns_report_path", paths.dnsReport);
   appendState("ready_path", paths.ready);
   run("/usr/bin/sudo", [
     "/usr/bin/systemd-run",
@@ -132,8 +124,7 @@ function main(): void {
     "--config",
     paths.config,
   ]);
-  const report = waitForReady(paths);
-  appendSummary(report);
+  waitForReady(paths);
   process.stdout.write("Fence readiness verified; resident controls remain active until runner teardown.\n");
 }
 

--- a/action/post.cts
+++ b/action/post.cts
@@ -23,19 +23,30 @@ function emitError(error: unknown): void {
 function main(): void {
   const invocationId = process.env.STATE_invocation_id;
   const reportPath = process.env.STATE_report_path;
-  if (!invocationId || runtimePaths(invocationId).report !== reportPath) {
+  const dnsReportPath = process.env.STATE_dns_report_path;
+  const paths = invocationId ? runtimePaths(invocationId) : undefined;
+  if (!invocationId || !paths || paths.report !== reportPath) {
     throw new Error("Fence post-job report path is missing or invalid");
+  }
+  if (dnsReportPath && paths.dnsReport !== dnsReportPath) {
+    throw new Error("Fence post-job DNS report path is invalid");
   }
   validateBundle(MANIFEST, BINARY);
   const report = validateReport(
     readJsonBounded(reportPath, MAX_REPORT_BYTES, "Fence report"),
-    true,
+    false,
   );
+  let dnsEvidence;
+  const effectiveDnsReportPath = dnsReportPath || paths.dnsReport;
+  if (fs.existsSync(effectiveDnsReportPath)) {
+    dnsEvidence = readJsonBounded(effectiveDnsReportPath, MAX_REPORT_BYTES, "Fence DNS report");
+  }
   if (process.env.GITHUB_STEP_SUMMARY) {
-    fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, summaryLines(report).join("\n"), {
+    fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, summaryLines(report, dnsEvidence).join("\n"), {
       encoding: "utf8",
     });
   }
+  validateReport(report, true);
   process.stdout.write("Fence post-job local evidence verified; resident controls remain active until runner teardown.\n");
 }
 

--- a/action/test.cts
+++ b/action/test.cts
@@ -329,6 +329,44 @@ test("renders audit IP-only and missing-DNS fallbacks safely", () => {
   assert.doesNotMatch(summary, /View allowlist example/);
 });
 
+test("renders audit IP-only findings when DNS evidence excludes non-GitHub names", () => {
+  const audit = {
+    ...report,
+    status: "protected_host_audit_observation",
+    mode: "audit",
+    readiness_status: "ready_observation_only",
+    setup_status: "resident_observation_only",
+    protection_available: false,
+    sudo_status: "preserved_verified",
+    container_status: "preserved_verified",
+    findings: [
+      {
+        timestamp: "unix-ms:1",
+        mode: "audit",
+        classification: "would_block",
+        family: "ipv4",
+        protocol: "tcp",
+        remote_address: "203.0.113.10",
+        remote_port: 443,
+        rule_class: "undeclared_new_egress",
+      },
+    ],
+    findings_truncated: false,
+  };
+  const dnsEvidence = {
+    observations: [],
+    observations_truncated: false,
+    excluded_non_github_query_count: 2,
+  };
+
+  const summary = summaryLines(audit, dnsEvidence).join("\n");
+  assert.match(summary, /^### 🟢 Fence Summary/);
+  assert.match(summary, /\| `203.0.113.10` \| `tcp` \| `443` \| `1` \|/);
+  assert.match(summary, /Manual review required for IP-only findings/);
+  assert.doesNotMatch(summary, /DNS audit evidence was unavailable/);
+  assert.doesNotMatch(summary, /View allowlist example/);
+});
+
 test("renders bounded allowlist YAML snippets", () => {
   const snippet = allowlistYamlSnippet([
     {

--- a/action/test.cts
+++ b/action/test.cts
@@ -7,6 +7,8 @@ const os = require("node:os");
 const path = require("node:path");
 const test = require("node:test");
 const {
+  allowlistYamlSnippet,
+  correlateFindingsToDns,
   defaultInlineConfig,
   runtimePaths,
   summaryLines,
@@ -111,13 +113,14 @@ test("derives only bounded fixed runtime paths", () => {
     config: "/run/fence/action-test/config.json",
     ready: "/run/fence/action-test/ready.json",
     report: "/run/fence/action-test/report.json",
+    dnsReport: "/run/fence/action-test/dns-report.json",
     unit: "fence-action-test.service",
   });
   assert.throws(() => runtimePaths("../action-test"), /slug grammar/);
   assert.throws(() => runtimePaths("action--test"), /slug grammar/);
 });
 
-test("validates stable runtime evidence and sanitizes summaries", () => {
+test("validates stable runtime evidence", () => {
   validateReport(report);
   validateReady({
     runtime_evidence_schema_version: 1,
@@ -130,8 +133,6 @@ test("validates stable runtime evidence and sanitizes summaries", () => {
     ruleset_hash: report.ruleset_hash,
     protection_available: true,
   }, report);
-  assert.match(summaryLines(report).join("\n"), /critical findings \| `0`/);
-  assert.doesNotMatch(summaryLines({ ...report, mode: "block\n| injected" }).join("\n"), /\n\| injected/);
   assert.throws(() => validateReport({ ...report, critical_findings: [{}] }), /critical resident findings/);
   assert.throws(
     () => validateReport({ ...report, network_verification_status: "critical_drift", critical_findings: [{}] }),
@@ -142,6 +143,211 @@ test("validates stable runtime evidence and sanitizes summaries", () => {
   assert.throws(() => validateReport({ ...report, sudo_status: "preserved_verified" }), /inconsistent/);
   assert.throws(() => validateReport({ ...report, runtime_evidence_schema_version: 0 }), /profile/);
   assert.throws(() => validateReady({ status: "ready" }, report), /identity/);
+});
+
+test("renders a concise healthy block summary without raw evidence fields", () => {
+  const summary = summaryLines(report).join("\n");
+  assert.match(summary, /^### 🟢 Fence Summary/);
+  assert.match(summary, /\*\*Network restrictions active\*\*/);
+  assert.match(summary, /GitHub workflow support channel/);
+  assert.equal(summary.match(/Fence Summary/g)?.length, 1);
+  assert.doesNotMatch(summary, /Fence local evidence/);
+  assert.doesNotMatch(summary, /critical findings/i);
+  assert.doesNotMatch(summary, /platform profile/i);
+  assert.doesNotMatch(summary, /readiness/i);
+  assert.doesNotMatch(summary, /protected_host_block/);
+  assert.doesNotMatch(summaryLines({ ...report, mode: "block\n| injected" }).join("\n"), /\n\| injected/);
+});
+
+test("renders degraded and critical summaries without a healthy signal", () => {
+  const degraded = {
+    ...report,
+    status: "protected_host_block_degraded",
+    readiness_status: "ready_degraded",
+    setup_status: "resident_degraded",
+    protection_available: false,
+    container_status: "preserved_unsafe",
+  };
+  validateReport(degraded);
+  const degradedSummary = summaryLines(degraded).join("\n");
+  assert.match(degradedSummary, /^### Fence Summary/);
+  assert.doesNotMatch(degradedSummary, /🟢/);
+  assert.match(degradedSummary, /\*\*Limited assurance\*\*/);
+  assert.match(degradedSummary, /Docker\/container access was preserved/);
+
+  const critical = {
+    ...report,
+    network_verification_status: "critical_drift",
+    critical_findings: [{
+      timestamp: "unix-ms:1",
+      code: "owned_nftables_state_missing",
+      message: "Fence-owned network state changed after readiness.",
+    }],
+  };
+  validateReport(critical, false);
+  assert.throws(() => validateReport(critical, true), /critical resident findings/);
+  const criticalSummary = summaryLines(critical).join("\n");
+  assert.match(criticalSummary, /^### Fence Summary/);
+  assert.doesNotMatch(criticalSummary, /🟢/);
+  assert.match(criticalSummary, /\*\*Fence needs attention\*\*/);
+  assert.match(criticalSummary, /`owned_nftables_state_missing`/);
+  assert.match(criticalSummary, /Fence-owned network state changed after readiness/);
+});
+
+test("renders audit would-block findings with DNS-backed allowlist guidance", () => {
+  const audit = {
+    ...report,
+    status: "protected_host_audit_observation",
+    mode: "audit",
+    readiness_status: "ready_observation_only",
+    setup_status: "resident_observation_only",
+    protection_available: false,
+    sudo_status: "preserved_verified",
+    container_status: "preserved_verified",
+    findings: [
+      {
+        timestamp: "unix-ms:1",
+        mode: "audit",
+        classification: "would_block",
+        family: "ipv4",
+        protocol: "tcp",
+        remote_address: "203.0.113.10",
+        remote_port: 443,
+        rule_class: "undeclared_new_egress",
+        ignored_payload: "secret-payload-marker",
+      },
+      {
+        timestamp: "unix-ms:2",
+        mode: "audit",
+        classification: "would_block",
+        family: "ipv4",
+        protocol: "tcp",
+        remote_address: "203.0.113.10",
+        remote_port: 443,
+        rule_class: "undeclared_new_egress",
+      },
+      {
+        timestamp: "unix-ms:3",
+        mode: "audit",
+        classification: "would_block",
+        family: "ipv4",
+        protocol: "udp",
+        remote_address: "192.0.2.10",
+        remote_port: 443,
+        rule_class: "undeclared_new_egress",
+      },
+    ],
+    findings_truncated: false,
+  };
+  const dnsEvidence = {
+    observations: [{
+      hostname: "www.google.com",
+      query_type: "a",
+      profile_classification: "audit_observed_without_authorization",
+      occurrences: 1,
+      resolved_addresses: ["203.0.113.10"],
+      minimum_observed_ttl_seconds: 60,
+      addresses_truncated: false,
+    }],
+    observations_truncated: false,
+  };
+
+  validateReport(audit);
+  const correlation = correlateFindingsToDns(audit, dnsEvidence);
+  assert.deepEqual(correlation.hostnameRows, [{
+    destination: "www.google.com",
+    destinationKind: "hostname",
+    protocol: "tcp",
+    port: 443,
+    count: 2,
+  }]);
+  assert.deepEqual(correlation.ipRows, [{
+    destination: "192.0.2.10",
+    destinationKind: "ip",
+    protocol: "udp",
+    port: 443,
+    count: 1,
+  }]);
+
+  const summary = summaryLines(audit, dnsEvidence).join("\n");
+  assert.match(summary, /^### 🟢 Fence Summary/);
+  assert.match(summary, /\*\*Observing only\*\*/);
+  assert.match(summary, /#### Would Be Blocked In Block Mode/);
+  assert.match(summary, /\| `www.google.com` \| `tcp` \| `443` \| `2` \|/);
+  assert.match(summary, /\| `192.0.2.10` \| `udp` \| `443` \| `1` \|/);
+  assert.match(summary, /<summary>View allowlist example<\/summary>/);
+  assert.match(summary, /```yaml/);
+  assert.match(summary, /GrantBirki\/fence@<commit-sha>/);
+  assert.match(summary, /"schema_version": 1/);
+  assert.match(summary, /"mode": "block"/);
+  assert.match(summary, /"allowlist": \[/);
+  assert.match(summary, /"destination": "www.google.com"/);
+  assert.doesNotMatch(summary, /@main/);
+  assert.doesNotMatch(summary, /secret-payload-marker/);
+});
+
+test("renders audit IP-only and missing-DNS fallbacks safely", () => {
+  const audit = {
+    ...report,
+    status: "protected_host_audit_observation",
+    mode: "audit",
+    readiness_status: "ready_observation_only",
+    setup_status: "resident_observation_only",
+    protection_available: false,
+    sudo_status: "preserved_verified",
+    container_status: "preserved_verified",
+    findings: [
+      {
+        timestamp: "unix-ms:1",
+        mode: "audit",
+        classification: "would_block",
+        family: "ipv4",
+        protocol: "udp",
+        remote_address: "192.0.2.10",
+        remote_port: 443,
+        rule_class: "undeclared_new_egress",
+      },
+      {
+        timestamp: "unix-ms:2",
+        mode: "audit",
+        classification: "would_block",
+        family: "ipv6",
+        protocol: "unknown_or_unparsed",
+        remote_address: null,
+        remote_port: null,
+        rule_class: "endpoint_unavailable_from_prefix",
+      },
+    ],
+    findings_truncated: false,
+  };
+  const summary = summaryLines(audit).join("\n");
+  assert.match(summary, /^### Fence Summary/);
+  assert.doesNotMatch(summary, /🟢/);
+  assert.match(summary, /DNS audit evidence was unavailable/);
+  assert.match(summary, /Manual review required for IP-only findings/);
+  assert.match(summary, /could not be mapped to an endpoint/);
+  assert.doesNotMatch(summary, /View allowlist example/);
+});
+
+test("renders bounded allowlist YAML snippets", () => {
+  const snippet = allowlistYamlSnippet([
+    {
+      destination: "api.example.com",
+      destinationKind: "hostname",
+      protocol: "tcp",
+      port: 443,
+      count: 5,
+    },
+  ]).join("\n");
+  assert.match(snippet.trimStart(), /^<details>/);
+  assert.match(snippet, /<summary>View allowlist example<\/summary>/);
+  assert.match(snippet, /```yaml/);
+  assert.match(snippet, /GrantBirki\/fence@<commit-sha>/);
+  assert.match(snippet, /"schema_version": 1/);
+  assert.match(snippet, /"invocation_id": "example-run"/);
+  assert.match(snippet, /"allowlist": \[/);
+  assert.match(snippet, /"destination": "api.example.com"/);
+  assert.doesNotMatch(snippet, /@main/);
 });
 
 test("rejects the retired status-only profile identity", () => {

--- a/script/test-action-acceptance
+++ b/script/test-action-acceptance
@@ -122,18 +122,11 @@ if scenario == "audit":
     assert report["counters"]["total_violations"] >= 1, report
     assert report["counters"]["sampled_violations"] >= 1, report
     assert any(item["classification"] == "would_block" for item in report["findings"]), report
-    google_addresses = {
-        address
-        for item in dns["observations"]
-        if item["hostname"] == "www.google.com" and item["query_type"] in ("a", "aaaa")
-        for address in item["resolved_addresses"]
-    }
-    assert google_addresses, dns
+    assert dns["excluded_non_github_query_count"] >= 1, dns
     assert any(
         item["classification"] == "would_block"
         and item["protocol"] == "tcp"
         and item["remote_port"] == 443
-        and item["remote_address"] in google_addresses
         for item in report["findings"]
     ), report
 PY

--- a/script/test-action-acceptance
+++ b/script/test-action-acceptance
@@ -22,6 +22,7 @@ if [[ "$PLATFORM" != "linux" || "$ARCH" != "x86_64" ]]; then
 fi
 
 require_cmd docker
+require_cmd curl
 require_cmd python3
 require_cmd sudo
 
@@ -100,6 +101,7 @@ import socket
 sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 sock.sendto(b"fence-action-audit-probe", ("192.0.2.10", 443))
 PY
+  curl --head --silent --show-error --max-time 10 --retry 0 https://www.google.com >/dev/null
 fi
 
 sleep 6
@@ -120,6 +122,20 @@ if scenario == "audit":
     assert report["counters"]["total_violations"] >= 1, report
     assert report["counters"]["sampled_violations"] >= 1, report
     assert any(item["classification"] == "would_block" for item in report["findings"]), report
+    google_addresses = {
+        address
+        for item in dns["observations"]
+        if item["hostname"] == "www.google.com" and item["query_type"] in ("a", "aaaa")
+        for address in item["resolved_addresses"]
+    }
+    assert google_addresses, dns
+    assert any(
+        item["classification"] == "would_block"
+        and item["protocol"] == "tcp"
+        and item["remote_port"] == 443
+        and item["remote_address"] in google_addresses
+        for item in report["findings"]
+    ), report
 PY
 
 echo -e "${GREEN}Action acceptance verified:${OFF} $scenario"


### PR DESCRIPTION
## 🟢 Summary

This PR replaces the raw duplicated Fence local evidence table with a single post-job `Fence Summary` that uses concise mode-aware wording. Audit mode now correlates DNS observations with would-block findings and renders bounded `allowlist` guidance, including a collapsed YAML example for moving to block mode.

## 🔒 Notes

It does not change enforcement behavior, runtime config, or the agent evidence schema.