### PR TITLE
Bump release version to 0.1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "fence"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "clap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fence"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 rust-version = "1.95.0"
 


### PR DESCRIPTION
## 🚀 Summary

Bumps the Fence agent source version to `0.1.6` so the next release can publish a binary that includes the broad GitHub domain opt-out support.