### PR TITLE
Bump Fence to 0.1.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "fence"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "clap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fence"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 rust-version = "1.96.0"
 


### PR DESCRIPTION
Bumps Fence to `v0.1.7` so the merged hosted-runner fingerprint tolerance can be published as a release artifact.