### PR TITLE
Improve Fence Action logs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,6 +190,7 @@ All scripts live in `script/` and should use `set -euo pipefail` unless there is
 - `script/test-action-wrapper`
   - Offline-only dependency-free TypeScript and Node built-in `node:test` checks for the Action launcher, report validation, concise job-summary rendering, audit allowlist guidance, critical-finding propagation, runtime-path derivation, and bundle checksum validation.
   - The wrapper uses Node 24 built-in type stripping and Node standard-library modules only. Do not add `npm`, `package.json`, `node_modules`, external Node packages, or a runtime compilation step.
+  - Action logs should stay concise by default and may use emoji plus ANSI colors for human readability. Debug logs are allowed only through GitHub Actions debug mode, must remain bounded and sanitized, and must not print raw config bodies, environment dumps, tokens, packet payloads, raw DNS packets, unrelated system logs, or arbitrary report JSON.
   - Proves that omitted Action input derives a bounded invocation identifier from GitHub run metadata and emits strict schema-`1` standard block with an empty `allowlist`; also proves native `mode`, `invocation_id`, `container_policy`, `platform_profile`, `disable_broad_github_domains`, and multiline `allowlist` inputs without requiring raw JSON config.
   - Keeps raw `config` as an advanced strict-JSON escape hatch and rejects any attempt to combine it with native config inputs.
   - The wrapper and hosted acceptance assertions require runtime-evidence schema `1` and stable profile-realization fields.

--- a/README.md
+++ b/README.md
@@ -181,6 +181,15 @@ Fence supports only GitHub-hosted `ubuntu-24.04` x64 host jobs today. The
 `ubuntu-latest` canary is useful signal, but it does not expand the support
 claim. Pin Fence to a full immutable commit SHA, not `@main`.
 
+## Troubleshooting 🧯
+
+Fence prints a short progress log during setup and a concise **Fence Summary**
+at the end of the job. If setup fails and you need more detail, enable the
+standard GitHub Actions debug flag by setting the repository secret
+`ACTIONS_STEP_DEBUG` to `true`. Debug logs include bounded service status and
+Fence-specific diagnostics, but they avoid raw config bodies, environment
+values, packet payloads, and unrelated system logs.
+
 ## Local Development ✈️
 
 Fence follows the airplane-test model described in

--- a/action/log.cts
+++ b/action/log.cts
@@ -1,0 +1,180 @@
+"use strict";
+
+const MAX_LOG_LINE_BYTES = 2048;
+const MAX_DEBUG_LINE_BYTES = 4096;
+
+type LogEnvironment = Record<string, string | undefined>;
+type ColorName = "highlight" | "info" | "success" | "warning" | "error";
+type ConfigLogDetails = {
+  mode: string;
+  source: string;
+  containerPolicy: string;
+  platformProfile: string;
+  disableBroadGithubDomains: boolean;
+  allowlistCount: number;
+  allowlistDestinations: string[];
+};
+
+const COLORS: Record<ColorName, string> = {
+  highlight: "\u001b[35m",
+  info: "\u001b[34m",
+  success: "\u001b[32m",
+  warning: "\u001b[33m",
+  error: "\u001b[31m",
+};
+const RESET = "\u001b[0m";
+
+function truncateUtf8(value: string, maximumBytes: number): string {
+  if (Buffer.byteLength(value, "utf8") <= maximumBytes) {
+    return value;
+  }
+  let truncated = value;
+  const marker = "...[truncated]";
+  while (truncated.length > 0 && Buffer.byteLength(`${truncated}${marker}`, "utf8") > maximumBytes) {
+    truncated = truncated.slice(0, -1);
+  }
+  return `${truncated}${marker}`;
+}
+
+function sanitizeLogText(value: unknown, maximumBytes = MAX_LOG_LINE_BYTES): string {
+  const sanitized = String(value)
+    .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, "_")
+    .replace(/[\r\n]+/g, " ");
+  return truncateUtf8(sanitized.startsWith("::") ? `_${sanitized}` : sanitized, maximumBytes);
+}
+
+function workflowEscape(value: unknown): string {
+  return sanitizeLogText(value, MAX_DEBUG_LINE_BYTES)
+    .replace(/%/g, "%25")
+    .replace(/\r/g, "%0D")
+    .replace(/\n/g, "%0A");
+}
+
+function colorize(value: string, color: ColorName, environment: LogEnvironment = process.env): string {
+  if (environment.NO_COLOR !== undefined && environment.NO_COLOR !== "") {
+    return value;
+  }
+  return `${COLORS[color]}${value}${RESET}`;
+}
+
+function debugEnabled(environment: LogEnvironment = process.env): boolean {
+  return environment.RUNNER_DEBUG === "1" || environment.ACTIONS_STEP_DEBUG === "true";
+}
+
+function info(message: string): void {
+  process.stdout.write(`${sanitizeLogText(message)}\n`);
+}
+
+function success(message: string, environment: LogEnvironment = process.env): void {
+  process.stdout.write(`${colorize(sanitizeLogText(message), "success", environment)}\n`);
+}
+
+function warning(message: string): void {
+  process.stdout.write(`::warning::${workflowEscape(message)}\n`);
+}
+
+function error(message: string): void {
+  process.stderr.write(`::error::${workflowEscape(message)}\n`);
+}
+
+function debug(message: string, environment: LogEnvironment = process.env): void {
+  if (!debugEnabled(environment)) {
+    return;
+  }
+  process.stdout.write(`::debug::${workflowEscape(message)}\n`);
+}
+
+function debugGroup(title: string, lines: unknown[], environment: LogEnvironment = process.env): void {
+  if (!debugEnabled(environment)) {
+    return;
+  }
+  process.stdout.write(`::group::${workflowEscape(title)}\n`);
+  for (const line of lines) {
+    process.stdout.write(`${sanitizeLogText(line, MAX_DEBUG_LINE_BYTES)}\n`);
+  }
+  process.stdout.write("::endgroup::\n");
+}
+
+function formatAllowlistEntry(entry: any): string | undefined {
+  if (entry === null || Array.isArray(entry) || typeof entry !== "object") {
+    return undefined;
+  }
+  const destinationType = typeof entry.destination_type === "string" ? entry.destination_type : "unknown";
+  const destination = typeof entry.destination === "string" ? entry.destination : "unknown";
+  const protocol = typeof entry.protocol === "string" ? entry.protocol : "unknown";
+  const port = typeof entry.port === "number" ? String(entry.port) : "unknown";
+  return `${destinationType}:${destination}:${protocol}:${port}`;
+}
+
+function configLogDetails(rawConfig: string, usingDefault: boolean): ConfigLogDetails {
+  const parsed = JSON.parse(rawConfig);
+  const allowlist = Array.isArray(parsed.allowlist) ? parsed.allowlist : [];
+  const mode = typeof parsed.mode === "string" ? parsed.mode : "unknown";
+  return {
+    mode,
+    source: usingDefault ? "native inputs" : "raw config",
+    containerPolicy: typeof parsed.container_policy === "string"
+      ? parsed.container_policy
+      : mode === "audit"
+        ? "not used"
+        : "disable",
+    platformProfile: typeof parsed.platform_profile === "string"
+      ? parsed.platform_profile
+      : "github_hosted_workflow_bootstrap_v1",
+    disableBroadGithubDomains: parsed.disable_broad_github_domains === true,
+    allowlistCount: allowlist.length,
+    allowlistDestinations: allowlist.map(formatAllowlistEntry).filter((value: unknown) => typeof value === "string"),
+  };
+}
+
+function pluralize(count: number, singular: string, plural = `${singular}s`): string {
+  return count === 1 ? singular : plural;
+}
+
+function setupLines(manifest: any, details: ConfigLogDetails): string[] {
+  const version = typeof manifest.release_tag === "string" ? manifest.release_tag : "unknown";
+  const modeIcon = details.mode === "audit" ? "👀" : "🔒";
+  const policyPrefix = details.mode === "audit" ? "observing GitHub workflow traffic" : "GitHub workflow traffic";
+  return [
+    `🛡️ Fence ${version}`,
+    `${modeIcon} Mode: ${details.mode}`,
+    `🌐 Policy: ${policyPrefix} + ${details.allowlistCount} ${pluralize(details.allowlistCount, "allowlist entry", "allowlist entries")}`,
+  ];
+}
+
+function readyLine(report: any): string {
+  if (report.status === "protected_host_audit_observation") {
+    return "✅ Fence ready: audit mode is observing traffic, not blocking it";
+  }
+  if (report.status === "protected_host_block_degraded") {
+    return "✅ Fence ready: network restrictions active; passwordless sudo locked down; Docker/container access preserved";
+  }
+  return "✅ Fence ready: network restrictions active; passwordless sudo and Docker/container access locked down";
+}
+
+function postEvidenceLine(report: any, auditDestinationCount = 0): string | undefined {
+  if (report.mode === "audit") {
+    return `👀 Audit observed ${auditDestinationCount} would-block ${pluralize(auditDestinationCount, "destination")}; see Fence Summary`;
+  }
+  if (report.status === "protected_host_block_degraded") {
+    return "⚠️ Limited assurance: Docker/container access was preserved";
+  }
+  return undefined;
+}
+
+module.exports = {
+  colorize,
+  configLogDetails,
+  debug,
+  debugEnabled,
+  debugGroup,
+  error,
+  info,
+  postEvidenceLine,
+  readyLine,
+  sanitizeLogText,
+  setupLines,
+  success,
+  warning,
+  workflowEscape,
+};

--- a/action/main.cts
+++ b/action/main.cts
@@ -3,6 +3,7 @@
 const fs = require("node:fs");
 const path = require("node:path");
 const { spawnSync } = require("node:child_process");
+const log = require("./log.cts");
 const {
   MAX_REPORT_BYTES,
   nativeInputsFromEnvironment,
@@ -26,9 +27,13 @@ const CHILD_ENV = {
   PATH: "/usr/bin:/usr/sbin:/bin:/sbin",
 };
 
+let diagnosticPaths: { unit: string } | undefined;
+let serviceLaunchAttempted = false;
+
 function emitError(error: unknown): void {
   const message = error instanceof Error ? error.message : String(error);
-  process.stderr.write(`::error::Fence setup failed: ${message.replace(/[\r\n%]/g, "_").slice(0, 512)}\n`);
+  log.error(`Fence setup failed: ${message}`);
+  emitServiceDiagnostics(diagnosticPaths);
 }
 
 function run(
@@ -56,6 +61,80 @@ function run(
   }
 }
 
+function capture(
+  executable: string,
+  args: string[],
+  timeout = 2 * 1000,
+): { status: number | null; stdout: string; stderr: string; error: string | undefined } {
+  const result = spawnSync(executable, args, {
+    encoding: "utf8",
+    env: CHILD_ENV,
+    killSignal: "SIGKILL",
+    maxBuffer: 32 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout,
+  });
+  return {
+    status: result.status,
+    stdout: String(result.stdout || ""),
+    stderr: String(result.stderr || ""),
+    error: result.error ? result.error.message : undefined,
+  };
+}
+
+function compactServiceStatus(output: string): string {
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .slice(0, 12)
+    .join("; ");
+}
+
+function emitServiceDiagnostics(paths: { unit: string } | undefined): void {
+  if (!paths || !serviceLaunchAttempted) {
+    return;
+  }
+  const status = capture("/usr/bin/systemctl", [
+    "show",
+    paths.unit,
+    "--no-pager",
+    "--property=LoadState",
+    "--property=ActiveState",
+    "--property=SubState",
+    "--property=Result",
+    "--property=ExecMainCode",
+    "--property=ExecMainStatus",
+    "--property=MainPID",
+  ]);
+  const compactStatus = compactServiceStatus(`${status.stdout}\n${status.stderr}`);
+  if (compactStatus.length > 0) {
+    log.warning(`Fence service state for ${paths.unit}: ${compactStatus}`);
+  }
+  log.debugGroup("Fence debug: service status", [
+    `unit=${paths.unit}`,
+    `status=${status.status}`,
+    `error=${status.error || "none"}`,
+    ...`${status.stdout}\n${status.stderr}`.split(/\r?\n/).filter((line) => line.length > 0),
+  ]);
+
+  const journal = capture("/usr/bin/journalctl", [
+    "--no-pager",
+    "--unit",
+    paths.unit,
+    "--lines",
+    "80",
+    "--output",
+    "short-monotonic",
+  ]);
+  log.debugGroup("Fence debug: service journal", [
+    `unit=${paths.unit}`,
+    `status=${journal.status}`,
+    `error=${journal.error || "none"}`,
+    ...`${journal.stdout}\n${journal.stderr}`.split(/\r?\n/).filter((line) => line.length > 0),
+  ]);
+}
+
 function sleep(milliseconds: number): void {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
 }
@@ -77,6 +156,12 @@ function appendState(name: string, value: string): void {
 
 function waitForReady(paths: { ready: string; report: string }): any {
   const deadline = Date.now() + READY_TIMEOUT_MS;
+  log.debugGroup("Fence debug: readiness", [
+    `timeout_ms=${READY_TIMEOUT_MS}`,
+    `poll_interval_ms=${POLL_INTERVAL_MS}`,
+    `ready_path=${paths.ready}`,
+    `report_path=${paths.report}`,
+  ]);
   while (Date.now() < deadline) {
     if (fs.existsSync(paths.ready) && fs.existsSync(paths.report)) {
       const report = validateReport(
@@ -85,6 +170,15 @@ function waitForReady(paths: { ready: string; report: string }): any {
       );
       const ready = readJsonBounded(paths.ready, 64 * 1024, "Fence readiness");
       validateReady(ready, report);
+      log.debugGroup("Fence debug: readiness verified", [
+        `mode=${report.mode}`,
+        `status=${report.status}`,
+        `readiness=${report.readiness_status}`,
+        `network_verification=${report.network_verification_status}`,
+        `sudo=${report.sudo_status}`,
+        `containers=${report.container_status}`,
+        `critical_findings=${Array.isArray(report.critical_findings) ? report.critical_findings.length : "unknown"}`,
+      ]);
       return report;
     }
     sleep(POLL_INTERVAL_MS);
@@ -96,9 +190,31 @@ function main(): void {
   if (process.platform !== "linux" || process.arch !== "x64") {
     throw new Error("Fence Action supports only Linux x64");
   }
-  validateBundle(MANIFEST, BINARY);
+  const manifest = validateBundle(MANIFEST, BINARY);
   const config = validateInlineConfig(process.env.INPUT_CONFIG, process.env, nativeInputsFromEnvironment(process.env));
   const paths = runtimePaths(config.invocationId);
+  diagnosticPaths = paths;
+  const details = log.configLogDetails(config.raw, config.usingDefault);
+
+  for (const line of log.setupLines(manifest, details)) {
+    log.info(line);
+  }
+  log.debugGroup("Fence debug: setup inputs", [
+    `mode=${details.mode}`,
+    `invocation_id=${config.invocationId}`,
+    `config_source=${details.source}`,
+    `container_policy=${details.containerPolicy}`,
+    `platform_profile=${details.platformProfile}`,
+    `disable_broad_github_domains=${details.disableBroadGithubDomains}`,
+    `allowlist_count=${details.allowlistCount}`,
+    ...details.allowlistDestinations.map((entry: string) => `allowlist=${entry}`),
+    `bundle_release=${manifest.release_tag}`,
+    `bundle_source_commit=${manifest.source_commit}`,
+    `platform=${process.platform}`,
+    `arch=${process.arch}`,
+    `runtime_directory=${paths.directory}`,
+    `unit=${paths.unit}`,
+  ]);
 
   if (fs.existsSync(paths.directory)) {
     throw new Error("Fence runtime invocation directory already exists");
@@ -113,7 +229,8 @@ function main(): void {
   appendState("report_path", paths.report);
   appendState("dns_report_path", paths.dnsReport);
   appendState("ready_path", paths.ready);
-  run("/usr/bin/sudo", [
+  log.info("🚀 Starting resident service");
+  const serviceArgs = [
     "/usr/bin/systemd-run",
     "--quiet",
     "--collect",
@@ -124,9 +241,16 @@ function main(): void {
     "run",
     "--config",
     paths.config,
+  ];
+  log.debugGroup("Fence debug: service launch", [
+    `executable=/usr/bin/sudo`,
+    `args=${serviceArgs.join(" ")}`,
+    `child_timeout_ms=${CHILD_TIMEOUT_MS}`,
   ]);
-  waitForReady(paths);
-  process.stdout.write("Fence readiness verified; resident controls remain active until runner teardown.\n");
+  serviceLaunchAttempted = true;
+  run("/usr/bin/sudo", serviceArgs);
+  const report = waitForReady(paths);
+  log.success(log.readyLine(report));
 }
 
 if (require.main === module) {

--- a/action/post.cts
+++ b/action/post.cts
@@ -2,7 +2,9 @@
 
 const fs = require("node:fs");
 const path = require("node:path");
+const log = require("./log.cts");
 const {
+  correlateFindingsToDns,
   MAX_REPORT_BYTES,
   readJsonBounded,
   runtimePaths,
@@ -17,10 +19,11 @@ const MANIFEST = path.join(ACTION_ROOT, "bundle-manifest.json");
 
 function emitError(error: unknown): void {
   const message = error instanceof Error ? error.message : String(error);
-  process.stderr.write(`::error::Fence post-job evidence failed: ${message.replace(/[\r\n%]/g, "_").slice(0, 512)}\n`);
+  log.error(`Fence post-job evidence failed: ${message}`);
 }
 
 function main(): void {
+  log.info("📋 Validating Fence evidence");
   const invocationId = process.env.STATE_invocation_id;
   const reportPath = process.env.STATE_report_path;
   const dnsReportPath = process.env.STATE_dns_report_path;
@@ -41,13 +44,39 @@ function main(): void {
   if (fs.existsSync(effectiveDnsReportPath)) {
     dnsEvidence = readJsonBounded(effectiveDnsReportPath, MAX_REPORT_BYTES, "Fence DNS report");
   }
+  const auditSummary = correlateFindingsToDns(report, dnsEvidence);
+  log.debugGroup("Fence debug: post-job evidence", [
+    `report_path=${reportPath}`,
+    `dns_report_path=${effectiveDnsReportPath}`,
+    `dns_report_present=${dnsEvidence !== undefined}`,
+    `mode=${report.mode}`,
+    `status=${report.status}`,
+    `readiness=${report.readiness_status}`,
+    `network_verification=${report.network_verification_status}`,
+    `sudo=${report.sudo_status}`,
+    `containers=${report.container_status}`,
+    `critical_findings=${Array.isArray(report.critical_findings) ? report.critical_findings.length : "unknown"}`,
+    `hostname_would_block_rows=${auditSummary.hostnameRows.length}`,
+    `ip_would_block_rows=${auditSummary.ipRows.length}`,
+    `unparsed_would_block_findings=${auditSummary.unparsedCount}`,
+    `source_truncated=${auditSummary.sourceTruncated}`,
+  ]);
   if (process.env.GITHUB_STEP_SUMMARY) {
     fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, summaryLines(report, dnsEvidence).join("\n"), {
       encoding: "utf8",
     });
   }
+  if (Array.isArray(report.critical_findings) && report.critical_findings.length > 0) {
+    log.warning(`Fence detected ${report.critical_findings.length} critical resident finding(s); failing this job`);
+  }
   validateReport(report, true);
-  process.stdout.write("Fence post-job local evidence verified; resident controls remain active until runner teardown.\n");
+  const auditDestinationCount = auditSummary.hostnameRows.length + auditSummary.ipRows.length;
+  const evidenceLine = log.postEvidenceLine(report, auditDestinationCount);
+  if (evidenceLine) {
+    log.info(evidenceLine);
+  }
+  log.success("✅ Fence evidence verified");
+  log.info("🧷 Fence remains active until the runner is torn down");
 }
 
 if (require.main === module) {

--- a/action/test.cts
+++ b/action/test.cts
@@ -17,6 +17,7 @@ const {
   validateReady,
   validateReport,
 } = require("./lib.cts");
+const actionLog = require("./log.cts");
 const { run } = require("./main.cts");
 
 const report = {
@@ -55,6 +56,36 @@ function manifestFor(binary: string, overrides = {}): Record<string, unknown> {
     attestation_verified: true,
     ...overrides,
   };
+}
+
+function captureStdout(callback: () => void): string {
+  const originalWrite = process.stdout.write;
+  let output = "";
+  process.stdout.write = ((chunk: unknown) => {
+    output += String(chunk);
+    return true;
+  }) as typeof process.stdout.write;
+  try {
+    callback();
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+  return output;
+}
+
+function captureStderr(callback: () => void): string {
+  const originalWrite = process.stderr.write;
+  let output = "";
+  process.stderr.write = ((chunk: unknown) => {
+    output += String(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    callback();
+  } finally {
+    process.stderr.write = originalWrite;
+  }
+  return output;
 }
 
 test("validates explicit and zero-input inline configurations", () => {
@@ -202,6 +233,140 @@ test("validates explicit and zero-input inline configurations", () => {
   assert.throws(
     () => validateInlineConfig(JSON.stringify({ invocation_id: "x", padding: "x".repeat(256 * 1024) })),
     /256 KiB/,
+  );
+});
+
+test("formats concise setup and ready logs without raw evidence fields", () => {
+  const details = actionLog.configLogDetails(
+    JSON.stringify({
+      schema_version: 1,
+      mode: "block",
+      invocation_id: "fence-12345-1",
+      allowlist: [
+        { destination_type: "hostname", destination: "api.example.com", protocol: "tcp", port: 443 },
+      ],
+    }),
+    true,
+  );
+  assert.equal(details.mode, "block");
+  assert.equal(details.source, "native inputs");
+  assert.equal(details.containerPolicy, "disable");
+  assert.equal(details.platformProfile, "github_hosted_workflow_bootstrap_v1");
+  assert.equal(details.disableBroadGithubDomains, false);
+  assert.equal(details.allowlistCount, 1);
+  assert.deepEqual(details.allowlistDestinations, ["hostname:api.example.com:tcp:443"]);
+
+  const lines = actionLog.setupLines({ release_tag: "v0.1.6" }, details).join("\n");
+  assert.match(lines, /🛡️ Fence v0\.1\.6/);
+  assert.match(lines, /🔒 Mode: block/);
+  assert.match(lines, /🌐 Policy: GitHub workflow traffic \+ 1 allowlist entry/);
+  assert.doesNotMatch(lines, /policy_hash/);
+  assert.doesNotMatch(lines, /runtime_evidence_schema_version/);
+
+  assert.equal(
+    actionLog.readyLine(report),
+    "✅ Fence ready: network restrictions active; passwordless sudo and Docker/container access locked down",
+  );
+});
+
+test("formats audit and degraded log wording accurately", () => {
+  const auditDetails = actionLog.configLogDetails(
+    '{"schema_version":1,"mode":"audit","invocation_id":"fence-12345-1","allowlist":[]}',
+    true,
+  );
+  assert.equal(actionLog.setupLines({ release_tag: "v0.1.6" }, auditDetails).join("\n"), [
+    "🛡️ Fence v0.1.6",
+    "👀 Mode: audit",
+    "🌐 Policy: observing GitHub workflow traffic + 0 allowlist entries",
+  ].join("\n"));
+
+  const auditReport = {
+    ...report,
+    status: "protected_host_audit_observation",
+    mode: "audit",
+    readiness_status: "ready_observation_only",
+    setup_status: "resident_observation_only",
+    protection_available: false,
+    sudo_status: "preserved_verified",
+    container_status: "preserved_verified",
+  };
+  assert.equal(
+    actionLog.readyLine(auditReport),
+    "✅ Fence ready: audit mode is observing traffic, not blocking it",
+  );
+  assert.equal(
+    actionLog.postEvidenceLine(auditReport, 2),
+    "👀 Audit observed 2 would-block destinations; see Fence Summary",
+  );
+
+  const degraded = {
+    ...report,
+    status: "protected_host_block_degraded",
+    readiness_status: "ready_degraded",
+    setup_status: "resident_degraded",
+    protection_available: false,
+    container_status: "preserved_unsafe",
+  };
+  assert.equal(
+    actionLog.readyLine(degraded),
+    "✅ Fence ready: network restrictions active; passwordless sudo locked down; Docker/container access preserved",
+  );
+  assert.equal(
+    actionLog.postEvidenceLine(degraded, 0),
+    "⚠️ Limited assurance: Docker/container access was preserved",
+  );
+});
+
+test("emits colored logs, respects NO_COLOR, and gates debug output", () => {
+  const colored = captureStdout(() => actionLog.success("✅ Fence evidence verified", {}));
+  assert.match(colored, /\u001b\[32m✅ Fence evidence verified\u001b\[0m/);
+
+  const plain = captureStdout(() => actionLog.success("✅ Fence evidence verified", { NO_COLOR: "1" }));
+  assert.equal(plain, "✅ Fence evidence verified\n");
+
+  assert.equal(captureStdout(() => actionLog.debug("hidden", {})), "");
+  assert.match(
+    captureStdout(() => actionLog.debug("visible", { RUNNER_DEBUG: "1" })),
+    /^::debug::visible\n$/,
+  );
+  assert.match(
+    captureStdout(() => actionLog.debug("visible", { ACTIONS_STEP_DEBUG: "true" })),
+    /^::debug::visible\n$/,
+  );
+});
+
+test("escapes workflow commands and bounds debug diagnostics", () => {
+  assert.equal(actionLog.workflowEscape("line one\nline two\r100%"), "line one line two 100%25");
+
+  const debug = captureStdout(() => actionLog.debugGroup(
+    "Fence debug: setup",
+    [
+      "normal line",
+      "::warning::injection",
+      "x".repeat(5000),
+    ],
+    { RUNNER_DEBUG: "1" },
+  ));
+  assert.match(debug, /^::group::Fence debug: setup\n/);
+  assert.match(debug, /normal line/);
+  assert.match(debug, /_::warning::injection/);
+  assert.match(debug, /\.\.\.\[truncated\]/);
+  assert.match(debug, /::endgroup::\n$/);
+
+  assert.equal(
+    captureStdout(() => actionLog.debugGroup("Fence debug: setup", ["hidden"], {})),
+    "",
+  );
+});
+
+test("emits bounded warning and error workflow commands", () => {
+  assert.equal(
+    captureStdout(() => actionLog.warning("Fence warning\n100%")),
+    "::warning::Fence warning 100%25\n",
+  );
+  assert.equal(
+    captureStderr(() => actionLog.error("Fence setup failed\n100%")),
+    "::error::Fence setup failed 100%25\n",
   );
 });
 


### PR DESCRIPTION
## TL;DR

Improves the Fence Action setup and post-job logs so normal runs show concise emoji-led status lines and debug mode exposes bounded diagnostics.

## Details

This adds a dependency-free wrapper logger with ANSI colors, GitHub workflow-command escaping, `NO_COLOR` support, and debug-only setup/service/evidence groups. It does not change the agent, config schema, enforcement behavior, or bundled binary.