### PR TITLE
Bump Fence to 0.1.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "fence"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "clap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fence"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 rust-version = "1.96.0"
 


### PR DESCRIPTION
## 🚀 Summary

Bumps Fence to `0.1.8` so the merged completion-driven DNS materialization fix can be published as a new attested Linux x64 agent release.
