### PR TITLE
Render Fence summary as result tables

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,9 +190,10 @@ All scripts live in `script/` and should use `set -euo pipefail` unless there is
   - Must never become an Action runtime step.
 
 - `script/test-action-wrapper`
-  - Offline-only dependency-free TypeScript and Node built-in `node:test` checks for the Action launcher, report validation, concise job-summary rendering, audit allowlist guidance, critical-finding propagation, runtime-path derivation, and bundle checksum validation.
+  - Offline-only dependency-free TypeScript and Node built-in `node:test` checks for the Action launcher, report validation, compact control and network-activity summary tables, audit allowlist guidance, critical-finding propagation, runtime-path derivation, and bundle checksum validation.
   - The wrapper uses Node 24 built-in type stripping and Node standard-library modules only. Do not add `npm`, `package.json`, `node_modules`, external Node packages, or a runtime compilation step.
   - Action logs should stay concise by default and may use emoji plus ANSI colors for human readability. Debug logs are allowed only through GitHub Actions debug mode, must remain bounded and sanitized, and must not print raw config bodies, environment dumps, tokens, packet payloads, raw DNS packets, unrelated system logs, or arbitrary report JSON.
+  - Job summaries should prefer bounded result tables over explanatory prose: show mode, network, sudo, and container outcomes plus reportable destinations and decisions; keep detailed evidence in local JSON and keep audit allowlist guidance collapsed.
   - Proves that omitted Action input derives a bounded invocation identifier from GitHub run metadata and emits strict schema-`1` standard block with an empty `allowlist`; also proves native `mode`, `invocation_id`, `container_policy`, `platform_profile`, `disable_broad_github_domains`, and multiline `allowlist` inputs without requiring raw JSON config.
   - Keeps raw `config` as an advanced strict-JSON escape hatch and rejects any attempt to combine it with native config inputs.
   - The wrapper and hosted acceptance assertions require runtime-evidence schema `1` and stable profile-realization fields.

--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ to `tcp` port `443`. IPv6 or non-hostname entries should use the explicit
    `allowlist`, blocks other outbound network access, turns off passwordless
    sudo, and disables Docker/container access.
 6. Fence keeps running until the runner is destroyed and records local evidence.
-7. The post-job hook prints a concise **Fence Summary** and fails the job if
-   Fence sees critical drift after startup.
+7. The post-job hook prints a compact **Fence Summary** with control results and
+   observed network activity, then fails the job if Fence sees critical drift.
 
 ```mermaid
 flowchart TD
@@ -184,8 +184,9 @@ claim. Pin Fence to a full immutable commit SHA, not `@main`.
 
 ## Troubleshooting 🧯
 
-Fence prints a short progress log during setup and a concise **Fence Summary**
-at the end of the job. If setup fails and you need more detail, enable the
+Fence prints a short progress log during setup and a compact **Fence Summary**
+with control and network-activity tables at the end of the job. If setup fails
+and you need more detail, enable the
 standard GitHub Actions debug flag by setting the repository secret
 `ACTIONS_STEP_DEBUG` to `true`. Debug logs include bounded service status and
 Fence-specific diagnostics, but they avoid raw config bodies, environment

--- a/action/lib.cts
+++ b/action/lib.cts
@@ -67,6 +67,12 @@ const MAX_REPORT_BYTES = 4 * 1024 * 1024;
 const MAX_AUDIT_HOSTNAME_ROWS = 10;
 const MAX_AUDIT_IP_ROWS = 10;
 const MAX_NETWORK_ACTIVITY_ROWS = 20;
+const ALLOWED_DNS_CLASSIFICATIONS = new Set([
+  "matches_selected_profile_pattern",
+  "matches_bounded_actions_suffix_authorization",
+  "matches_ttl_bounded_cname_descendant",
+]);
+const FORWARDED_DNS_QUERY_TYPES = new Set(["a", "aaaa"]);
 const INVOCATION_ID = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const DNS_HOSTNAME = /^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)*[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
 const REVIEWED_PLATFORM_PROFILE = "github_hosted_workflow_bootstrap_v1";
@@ -868,12 +874,23 @@ function safePositiveInteger(value: unknown): number {
   return Number.isSafeInteger(value) && value > 0 ? Number(value) : 0;
 }
 
-function networkDecision(report: any, classification: unknown): NetworkDecision {
-  const allowed = typeof classification === "string" && classification.startsWith("matches_");
+function networkDecision(report: any, classification: unknown, queryType: unknown): NetworkDecision {
+  const allowed = ALLOWED_DNS_CLASSIFICATIONS.has(classification) &&
+    FORWARDED_DNS_QUERY_TYPES.has(queryType);
   if (allowed) {
     return "allowed";
   }
   return report.mode === "audit" ? "would_block" : "blocked";
+}
+
+function dnsQueryActivity(queryType: unknown): string {
+  if (queryType === "a" || queryType === "aaaa") {
+    return `${queryType.toUpperCase()} query`;
+  }
+  if (typeof queryType === "string" && /^type_[0-9]{1,5}$/.test(queryType)) {
+    return `TYPE${queryType.slice(5)} query`;
+  }
+  return "DNS query";
 }
 
 function addNetworkActivity(
@@ -917,8 +934,12 @@ function networkActivityRows(
         continue;
       }
       const count = safePositiveInteger(observation.occurrences);
-      const decision = networkDecision(report, observation.profile_classification);
-      addNetworkActivity(rows, observation.hostname, decision, "DNS query", count);
+      const decision = networkDecision(
+        report,
+        observation.profile_classification,
+        observation.query_type,
+      );
+      addNetworkActivity(rows, observation.hostname, decision, dnsQueryActivity(observation.query_type), count);
       if (decision === "blocked") {
         namedBlockedDnsQueries += count;
       }
@@ -991,6 +1012,9 @@ function activityLabel(row: NetworkActivityRow): string {
       }
       if (activity === "DNS query (names not retained)") {
         return `${count} DNS ${count === 1 ? "query" : "queries"} (names not retained)`;
+      }
+      if (activity.endsWith(" query")) {
+        return `${count} ${activity.slice(0, -6)} ${count === 1 ? "query" : "queries"}`;
       }
       return `${count} ${activity}${count === 1 ? "" : "s"}`;
     })

--- a/action/lib.cts
+++ b/action/lib.cts
@@ -50,11 +50,23 @@ type AuditSummary = {
   unparsedCount: number;
   sourceTruncated: boolean;
 };
+type NetworkDecision = "allowed" | "blocked" | "would_block";
+type NetworkActivityRow = {
+  destination: string;
+  decision: NetworkDecision;
+  activities: Map<string, number>;
+  totalCount: number;
+};
+type NetworkActivitySummary = {
+  rows: NetworkActivityRow[];
+  omittedRows: number;
+};
 
 const MAX_CONFIG_BYTES = 256 * 1024;
 const MAX_REPORT_BYTES = 4 * 1024 * 1024;
 const MAX_AUDIT_HOSTNAME_ROWS = 10;
 const MAX_AUDIT_IP_ROWS = 10;
+const MAX_NETWORK_ACTIVITY_ROWS = 20;
 const INVOCATION_ID = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const DNS_HOSTNAME = /^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)*[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
 const REVIEWED_PLATFORM_PROFILE = "github_hosted_workflow_bootstrap_v1";
@@ -726,8 +738,11 @@ function correlateFindingsToDns(report: any, dnsEvidence: any = undefined): Audi
   };
 }
 
-function summaryHeading(summaryState: { healthy: boolean }): string {
-  return summaryState.healthy ? "### 🟢 Fence Summary" : "### Fence Summary";
+function summaryHeading(summaryState: { healthy: boolean; critical: boolean }): string {
+  if (summaryState.critical) {
+    return "### 🔴 Fence Summary";
+  }
+  return summaryState.healthy ? "### 🟢 Fence Summary" : "### 🟡 Fence Summary";
 }
 
 function summaryHasWarnings(report: any, auditSummary: AuditSummary, dnsEvidence: any): boolean {
@@ -761,9 +776,11 @@ function materializationWarningLines(dnsEvidence: any): string[] {
   }
   return [
     "",
-    "**Some DNS answers were withheld**",
+    "#### Warnings",
     "",
-    `Fence withheld ${count} DNS answer(s) because firewall update work could not be accepted. Clients may have retried those lookups.`,
+    "| Warning | Count |",
+    "| --- | ---: |",
+    `| ⚠️ DNS answers withheld while firewall updates were unavailable | ${markdownCode(count)} |`,
   ];
 }
 
@@ -773,51 +790,47 @@ function criticalFindingLines(report: any): string[] {
   }
   const lines = [
     "",
-    "| Finding | Detail |",
-    "| --- | --- |",
+    "#### Critical findings",
+    "",
+    "| Result | Finding | Detail |",
+    "| --- | --- | --- |",
   ];
   for (const finding of report.critical_findings.slice(0, 5)) {
-    lines.push(`| ${markdownCode(finding && finding.code)} | ${boundedText(finding && finding.message)} |`);
+    lines.push(`| ❌ Critical | ${markdownCode(finding && finding.code)} | ${boundedText(finding && finding.message)} |`);
   }
   if (report.critical_findings.length > 5) {
-    lines.push(`| ${markdownCode("additional_findings_omitted")} | ${report.critical_findings.length - 5} more critical findings are available in the local report. |`);
+    lines.push(`| ❌ Critical | ${markdownCode("additional_findings_omitted")} | ${report.critical_findings.length - 5} more critical findings are available in the local report. |`);
   }
   return lines;
 }
 
-function modeStatusCard(report: any): string[] {
-  if (
-    report.network_verification_status !== "verified" ||
-    (Array.isArray(report.critical_findings) && report.critical_findings.length > 0)
-  ) {
-    return [
-      "**Fence needs attention**",
-      "",
-      "Fence detected a critical issue after startup and marked this job as failed.",
-      ...criticalFindingLines(report),
-    ];
-  }
-
-  if (report.status === "protected_host_block_degraded") {
-    return [
-      "**Limited assurance**",
-      "",
-      "Fence limited outbound traffic and locked down passwordless sudo, but Docker/container access was preserved. Container access can bypass the ordinary containment claim.",
-    ];
-  }
-
-  if (report.mode === "audit") {
-    return [
-      "**Observing only**",
-      "",
-      "Fence did not block traffic in audit mode. The destinations below would need review before switching this workflow to block mode.",
-    ];
-  }
-
+function controlsSummary(report: any): string[] {
+  const network = report.network_verification_status !== "verified"
+    ? "❌ Verification failed"
+    : report.mode === "audit"
+      ? "⚠️ Observing only"
+      : "✅ Restricted";
+  const sudo = report.sudo_status === "disabled_verified"
+    ? "✅ Disabled"
+    : report.sudo_status === "preserved_verified"
+      ? "➖ Available in audit mode"
+      : "❌ Unverified";
+  const containers = report.container_status === "disabled_verified"
+    ? "✅ Disabled"
+    : report.container_status === "preserved_unsafe"
+      ? "⚠️ Available; limited assurance"
+      : report.container_status === "preserved_verified"
+        ? "➖ Available in audit mode"
+        : "❌ Unverified";
   return [
-    "**Network restrictions active**",
+    "#### Controls",
     "",
-    "Fence limited outbound traffic to the GitHub workflow support channel and your `allowlist`. Passwordless sudo and Docker/container access were locked down. Controls remain active until the runner is torn down.",
+    "| Control | Result |",
+    "| --- | --- |",
+    `| Mode | ${report.mode === "audit" ? "👀 Audit" : "🔒 Block"} |`,
+    `| Outbound network | ${network} |`,
+    `| Passwordless sudo | ${sudo} |`,
+    `| Docker/container access | ${containers} |`,
   ];
 }
 
@@ -851,54 +864,194 @@ function allowlistYamlSnippet(rows: AuditFindingRow[]): string[] {
   ];
 }
 
-function auditWouldBlockSummary(report: any, dnsEvidence: any = undefined, auditSummary: AuditSummary = correlateFindingsToDns(report, dnsEvidence)): string[] {
-  if (report.mode !== "audit") {
-    return [];
+function safePositiveInteger(value: unknown): number {
+  return Number.isSafeInteger(value) && value > 0 ? Number(value) : 0;
+}
+
+function networkDecision(report: any, classification: unknown): NetworkDecision {
+  const allowed = typeof classification === "string" && classification.startsWith("matches_");
+  if (allowed) {
+    return "allowed";
+  }
+  return report.mode === "audit" ? "would_block" : "blocked";
+}
+
+function addNetworkActivity(
+  rows: Map<string, NetworkActivityRow>,
+  destination: string,
+  decision: NetworkDecision,
+  activity: string,
+  count: number,
+): void {
+  if (count === 0) {
+    return;
+  }
+  const key = `${destination}\0${decision}`;
+  const row = rows.get(key) || {
+    destination,
+    decision,
+    activities: new Map<string, number>(),
+    totalCount: 0,
+  };
+  row.activities.set(activity, (row.activities.get(activity) || 0) + count);
+  row.totalCount += count;
+  rows.set(key, row);
+}
+
+function networkActivityRows(
+  report: any,
+  dnsEvidence: any,
+  auditSummary: AuditSummary,
+): NetworkActivitySummary {
+  const rows = new Map<string, NetworkActivityRow>();
+  let namedBlockedDnsQueries = 0;
+
+  if (dnsEvidence && Array.isArray(dnsEvidence.observations)) {
+    for (const observation of dnsEvidence.observations) {
+      if (
+        observation === null ||
+        Array.isArray(observation) ||
+        typeof observation !== "object" ||
+        !isSafeHostname(observation.hostname)
+      ) {
+        continue;
+      }
+      const count = safePositiveInteger(observation.occurrences);
+      const decision = networkDecision(report, observation.profile_classification);
+      addNetworkActivity(rows, observation.hostname, decision, "DNS query", count);
+      if (decision === "blocked") {
+        namedBlockedDnsQueries += count;
+      }
+    }
   }
 
-  const rows = [...auditSummary.hostnameRows, ...auditSummary.ipRows];
-  const lines = ["", "#### Would Be Blocked In Block Mode", ""];
-  if (auditSummary.dnsMissing) {
-    lines.push("DNS audit evidence was unavailable, so Fence could only report IP-level findings.", "");
+  if (report.mode === "audit") {
+    for (const row of [...auditSummary.hostnameRows, ...auditSummary.ipRows]) {
+      addNetworkActivity(
+        rows,
+        row.destination,
+        "would_block",
+        `${row.protocol.toUpperCase()}/${row.port} attempt`,
+        row.count,
+      );
+    }
+    addNetworkActivity(
+      rows,
+      "Other DNS names",
+      "would_block",
+      "DNS query (names not retained)",
+      safePositiveInteger(dnsEvidence && dnsEvidence.excluded_non_github_query_count),
+    );
+  } else {
+    const unnamedBlocked = Math.max(
+      0,
+      safePositiveInteger(dnsEvidence && dnsEvidence.blocked_non_profile_query_count) - namedBlockedDnsQueries,
+    );
+    addNetworkActivity(
+      rows,
+      "Other DNS names",
+      "blocked",
+      "DNS query (names not retained)",
+      unnamedBlocked,
+    );
   }
-  if (rows.length === 0 && auditSummary.unparsedCount === 0) {
-    lines.push("No would-block destinations were observed during this audit run.");
+
+  const priority: Record<NetworkDecision, number> = {
+    blocked: 0,
+    would_block: 1,
+    allowed: 2,
+  };
+  const sorted = Array.from(rows.values()).sort((left, right) =>
+    priority[left.decision] - priority[right.decision] ||
+    right.totalCount - left.totalCount ||
+    left.destination.localeCompare(right.destination)
+  );
+  return {
+    rows: sorted.slice(0, MAX_NETWORK_ACTIVITY_ROWS),
+    omittedRows: Math.max(0, sorted.length - MAX_NETWORK_ACTIVITY_ROWS),
+  };
+}
+
+function decisionLabel(decision: NetworkDecision): string {
+  if (decision === "allowed") {
+    return "✅ Allowed";
+  }
+  if (decision === "blocked") {
+    return "⛔ Blocked";
+  }
+  return "⚠️ Would block";
+}
+
+function activityLabel(row: NetworkActivityRow): string {
+  return Array.from(row.activities.entries())
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([activity, count]) => {
+      if (activity === "DNS query") {
+        return `${count} DNS ${count === 1 ? "query" : "queries"}`;
+      }
+      if (activity === "DNS query (names not retained)") {
+        return `${count} DNS ${count === 1 ? "query" : "queries"} (names not retained)`;
+      }
+      return `${count} ${activity}${count === 1 ? "" : "s"}`;
+    })
+    .join(", ");
+}
+
+function networkActivitySummary(
+  report: any,
+  dnsEvidence: any = undefined,
+  auditSummary: AuditSummary = correlateFindingsToDns(report, dnsEvidence),
+): string[] {
+  const activity = networkActivityRows(report, dnsEvidence, auditSummary);
+  const lines = ["", "#### Network activity", ""];
+  if (activity.rows.length === 0) {
+    lines.push("_No reportable network activity was observed._");
     return lines;
   }
 
-  if (rows.length > 0) {
-    lines.push("| Destination | Protocol | Port | Count |");
-    lines.push("| --- | --- | ---: | ---: |");
-    for (const row of rows) {
-      lines.push(`| ${markdownCode(row.destination)} | ${markdownCode(row.protocol)} | ${markdownCode(row.port)} | ${markdownCode(row.count)} |`);
-    }
-    lines.push("");
+  lines.push("| Destination | Result | Activity |");
+  lines.push("| --- | --- | ---: |");
+  for (const row of activity.rows) {
+    lines.push(`| ${markdownCode(row.destination)} | ${decisionLabel(row.decision)} | ${boundedText(activityLabel(row))} |`);
   }
-  if (auditSummary.ipRows.length > 0 && auditSummary.hostnameRows.length === 0) {
-    lines.push("Manual review required for IP-only findings.");
-    lines.push("");
+  if (activity.omittedRows > 0) {
+    lines.push(`| ${markdownCode("additional_destinations_omitted")} | ⚠️ Review local evidence | ${activity.omittedRows} more row(s) |`);
+  }
+  lines.push("");
+
+  if (report.mode === "audit" && auditSummary.dnsMissing) {
+    lines.push("⚠️ DNS evidence was unavailable; IP-level findings may require manual review.", "");
   }
   if (auditSummary.unparsedCount > 0) {
-    lines.push(`${auditSummary.unparsedCount} would-block finding(s) could not be mapped to an endpoint from the bounded packet prefix.`);
+    lines.push(`⚠️ ${auditSummary.unparsedCount} would-block finding(s) could not be mapped to an endpoint.`);
     lines.push("");
   }
   if (auditSummary.sourceTruncated || auditSummary.omittedHostnameRows > 0 || auditSummary.omittedIpRows > 0) {
     const omitted = auditSummary.omittedHostnameRows + auditSummary.omittedIpRows;
-    lines.push(`Some audit evidence was truncated or omitted from this summary. Review the local report for full bounded evidence${omitted > 0 ? `; ${omitted} grouped row(s) were omitted here` : ""}.`);
+    lines.push(`⚠️ Network evidence was truncated${omitted > 0 ? `; ${omitted} grouped row(s) were omitted` : ""}.`);
+    lines.push("");
   }
-  lines.push(...allowlistYamlSnippet(auditSummary.hostnameRows));
+  if (report.mode === "audit") {
+    lines.push(...allowlistYamlSnippet(auditSummary.hostnameRows));
+  }
   return lines;
 }
 
 function summaryLines(report: any, dnsEvidence: any = undefined): string[] {
   const auditSummary = correlateFindingsToDns(report, dnsEvidence);
-  const summaryState = { healthy: !summaryHasWarnings(report, auditSummary, dnsEvidence) };
+  const critical = report.network_verification_status !== "verified" ||
+    (Array.isArray(report.critical_findings) && report.critical_findings.length > 0);
+  const summaryState = {
+    healthy: !summaryHasWarnings(report, auditSummary, dnsEvidence),
+    critical,
+  };
   return [
     summaryHeading(summaryState),
     "",
-    ...modeStatusCard(report),
+    ...controlsSummary(report),
+    ...criticalFindingLines(report),
     ...materializationWarningLines(dnsEvidence),
-    ...auditWouldBlockSummary(report, dnsEvidence, auditSummary),
+    ...networkActivitySummary(report, dnsEvidence, auditSummary),
     "",
   ];
 }
@@ -906,13 +1059,13 @@ function summaryLines(report: any, dnsEvidence: any = undefined): string[] {
 module.exports = {
   MAX_REPORT_BYTES,
   allowlistYamlSnippet,
-  auditWouldBlockSummary,
   correlateFindingsToDns,
+  controlsSummary,
   defaultInlineConfig,
-  modeStatusCard,
   materializationRequestRejections,
   materializationEvidenceCounter,
   materializationWarningLines,
+  networkActivitySummary,
   nativeInputsFromEnvironment,
   readJsonBounded,
   runtimePaths,

--- a/action/test.cts
+++ b/action/test.cts
@@ -434,9 +434,16 @@ test("renders a concise healthy block results table without raw evidence fields"
         occurrences: 1,
         resolved_addresses: [],
       },
+      {
+        hostname: "github.com",
+        query_type: "type_15",
+        profile_classification: "matches_selected_profile_pattern",
+        occurrences: 1,
+        resolved_addresses: [],
+      },
     ],
     observations_truncated: false,
-    blocked_non_profile_query_count: 1,
+    blocked_non_profile_query_count: 2,
   };
   const summary = summaryLines(report, dnsEvidence).join("\n");
   assert.match(summary, /^### 🟢 Fence Summary/);
@@ -446,9 +453,10 @@ test("renders a concise healthy block results table without raw evidence fields"
   assert.match(summary, /\| Passwordless sudo \| ✅ Disabled \|/);
   assert.match(summary, /\| Docker\/container access \| ✅ Disabled \|/);
   assert.match(summary, /#### Network activity/);
-  assert.match(summary, /\| `github.com` \| ✅ Allowed \| 2 DNS queries \|/);
-  assert.match(summary, /\| `api.github.com` \| ✅ Allowed \| 1 DNS query \|/);
-  assert.match(summary, /\| `codeload.github.com` \| ⛔ Blocked \| 1 DNS query \|/);
+  assert.match(summary, /\| `github.com` \| ✅ Allowed \| 2 A queries \|/);
+  assert.match(summary, /\| `github.com` \| ⛔ Blocked \| 1 TYPE15 query \|/);
+  assert.match(summary, /\| `api.github.com` \| ✅ Allowed \| 1 AAAA query \|/);
+  assert.match(summary, /\| `codeload.github.com` \| ⛔ Blocked \| 1 A query \|/);
   assert.equal(summary.match(/Fence Summary/g)?.length, 1);
   assert.doesNotMatch(summary, /Fence local evidence/);
   assert.doesNotMatch(summary, /critical findings/i);
@@ -578,7 +586,7 @@ test("renders audit would-block findings with DNS-backed allowlist guidance", ()
   assert.match(summary, /\| Passwordless sudo \| ➖ Available in audit mode \|/);
   assert.match(summary, /\| Docker\/container access \| ➖ Available in audit mode \|/);
   assert.match(summary, /#### Network activity/);
-  assert.match(summary, /\| `www.google.com` \| ⚠️ Would block \| 1 DNS query, 2 TCP\/443 attempts \|/);
+  assert.match(summary, /\| `www.google.com` \| ⚠️ Would block \| 1 A query, 2 TCP\/443 attempts \|/);
   assert.match(summary, /\| `192.0.2.10` \| ⚠️ Would block \| 1 UDP\/443 attempt \|/);
   assert.match(summary, /<summary>View allowlist example<\/summary>/);
   assert.match(summary, /```yaml/);

--- a/action/test.cts
+++ b/action/test.cts
@@ -410,17 +410,52 @@ test("validates stable runtime evidence", () => {
   assert.throws(() => validateReady({ status: "ready" }, report), /identity/);
 });
 
-test("renders a concise healthy block summary without raw evidence fields", () => {
-  const summary = summaryLines(report).join("\n");
+test("renders a concise healthy block results table without raw evidence fields", () => {
+  const dnsEvidence = {
+    observations: [
+      {
+        hostname: "github.com",
+        query_type: "a",
+        profile_classification: "matches_selected_profile_pattern",
+        occurrences: 2,
+        resolved_addresses: ["192.0.2.1"],
+      },
+      {
+        hostname: "api.github.com",
+        query_type: "aaaa",
+        profile_classification: "matches_selected_profile_pattern",
+        occurrences: 1,
+        resolved_addresses: ["2001:db8::1"],
+      },
+      {
+        hostname: "codeload.github.com",
+        query_type: "a",
+        profile_classification: "github_related_outside_profile",
+        occurrences: 1,
+        resolved_addresses: [],
+      },
+    ],
+    observations_truncated: false,
+    blocked_non_profile_query_count: 1,
+  };
+  const summary = summaryLines(report, dnsEvidence).join("\n");
   assert.match(summary, /^### 🟢 Fence Summary/);
-  assert.match(summary, /\*\*Network restrictions active\*\*/);
-  assert.match(summary, /GitHub workflow support channel/);
+  assert.match(summary, /#### Controls/);
+  assert.match(summary, /\| Mode \| 🔒 Block \|/);
+  assert.match(summary, /\| Outbound network \| ✅ Restricted \|/);
+  assert.match(summary, /\| Passwordless sudo \| ✅ Disabled \|/);
+  assert.match(summary, /\| Docker\/container access \| ✅ Disabled \|/);
+  assert.match(summary, /#### Network activity/);
+  assert.match(summary, /\| `github.com` \| ✅ Allowed \| 2 DNS queries \|/);
+  assert.match(summary, /\| `api.github.com` \| ✅ Allowed \| 1 DNS query \|/);
+  assert.match(summary, /\| `codeload.github.com` \| ⛔ Blocked \| 1 DNS query \|/);
   assert.equal(summary.match(/Fence Summary/g)?.length, 1);
   assert.doesNotMatch(summary, /Fence local evidence/);
   assert.doesNotMatch(summary, /critical findings/i);
   assert.doesNotMatch(summary, /platform profile/i);
   assert.doesNotMatch(summary, /readiness/i);
   assert.doesNotMatch(summary, /protected_host_block/);
+  assert.doesNotMatch(summary, /Fence limited outbound traffic/);
   assert.doesNotMatch(summaryLines({ ...report, mode: "block\n| injected" }).join("\n"), /\n\| injected/);
 });
 
@@ -435,10 +470,10 @@ test("renders degraded and critical summaries without a healthy signal", () => {
   };
   validateReport(degraded);
   const degradedSummary = summaryLines(degraded).join("\n");
-  assert.match(degradedSummary, /^### Fence Summary/);
+  assert.match(degradedSummary, /^### 🟡 Fence Summary/);
   assert.doesNotMatch(degradedSummary, /🟢/);
-  assert.match(degradedSummary, /\*\*Limited assurance\*\*/);
-  assert.match(degradedSummary, /Docker\/container access was preserved/);
+  assert.match(degradedSummary, /\| Passwordless sudo \| ✅ Disabled \|/);
+  assert.match(degradedSummary, /\| Docker\/container access \| ⚠️ Available; limited assurance \|/);
 
   const critical = {
     ...report,
@@ -452,9 +487,11 @@ test("renders degraded and critical summaries without a healthy signal", () => {
   validateReport(critical, false);
   assert.throws(() => validateReport(critical, true), /critical resident findings/);
   const criticalSummary = summaryLines(critical).join("\n");
-  assert.match(criticalSummary, /^### Fence Summary/);
+  assert.match(criticalSummary, /^### 🔴 Fence Summary/);
   assert.doesNotMatch(criticalSummary, /🟢/);
-  assert.match(criticalSummary, /\*\*Fence needs attention\*\*/);
+  assert.match(criticalSummary, /\| Outbound network \| ❌ Verification failed \|/);
+  assert.match(criticalSummary, /#### Critical findings/);
+  assert.match(criticalSummary, /\| ❌ Critical \|/);
   assert.match(criticalSummary, /`owned_nftables_state_missing`/);
   assert.match(criticalSummary, /Fence-owned network state changed after readiness/);
 });
@@ -536,10 +573,13 @@ test("renders audit would-block findings with DNS-backed allowlist guidance", ()
 
   const summary = summaryLines(audit, dnsEvidence).join("\n");
   assert.match(summary, /^### 🟢 Fence Summary/);
-  assert.match(summary, /\*\*Observing only\*\*/);
-  assert.match(summary, /#### Would Be Blocked In Block Mode/);
-  assert.match(summary, /\| `www.google.com` \| `tcp` \| `443` \| `2` \|/);
-  assert.match(summary, /\| `192.0.2.10` \| `udp` \| `443` \| `1` \|/);
+  assert.match(summary, /\| Mode \| 👀 Audit \|/);
+  assert.match(summary, /\| Outbound network \| ⚠️ Observing only \|/);
+  assert.match(summary, /\| Passwordless sudo \| ➖ Available in audit mode \|/);
+  assert.match(summary, /\| Docker\/container access \| ➖ Available in audit mode \|/);
+  assert.match(summary, /#### Network activity/);
+  assert.match(summary, /\| `www.google.com` \| ⚠️ Would block \| 1 DNS query, 2 TCP\/443 attempts \|/);
+  assert.match(summary, /\| `192.0.2.10` \| ⚠️ Would block \| 1 UDP\/443 attempt \|/);
   assert.match(summary, /<summary>View allowlist example<\/summary>/);
   assert.match(summary, /```yaml/);
   assert.match(summary, /GrantBirki\/fence@<commit-sha>/);
@@ -586,10 +626,10 @@ test("renders audit IP-only and missing-DNS fallbacks safely", () => {
     findings_truncated: false,
   };
   const summary = summaryLines(audit).join("\n");
-  assert.match(summary, /^### Fence Summary/);
+  assert.match(summary, /^### 🟡 Fence Summary/);
   assert.doesNotMatch(summary, /🟢/);
-  assert.match(summary, /DNS audit evidence was unavailable/);
-  assert.match(summary, /Manual review required for IP-only findings/);
+  assert.match(summary, /DNS evidence was unavailable; IP-level findings may require manual review/);
+  assert.match(summary, /\| `192.0.2.10` \| ⚠️ Would block \| 1 UDP\/443 attempt \|/);
   assert.match(summary, /could not be mapped to an endpoint/);
   assert.doesNotMatch(summary, /View allowlist example/);
 });
@@ -626,9 +666,8 @@ test("renders audit IP-only findings when DNS evidence excludes non-GitHub names
 
   const summary = summaryLines(audit, dnsEvidence).join("\n");
   assert.match(summary, /^### 🟢 Fence Summary/);
-  assert.match(summary, /\| `203.0.113.10` \| `tcp` \| `443` \| `1` \|/);
-  assert.match(summary, /Manual review required for IP-only findings/);
-  assert.doesNotMatch(summary, /DNS audit evidence was unavailable/);
+  assert.match(summary, /\| `203.0.113.10` \| ⚠️ Would block \| 1 TCP\/443 attempt \|/);
+  assert.doesNotMatch(summary, /DNS evidence was unavailable/);
   assert.doesNotMatch(summary, /View allowlist example/);
 });
 
@@ -643,13 +682,14 @@ test("renders DNS materialization request rejection evidence as a non-critical w
   assert.equal(materializationRequestRejections({ materialization_request_rejections: "2" }), 0);
   assert.match(
     materializationWarningLines(dnsEvidence).join("\n"),
-    /withheld 2 DNS answer\(s\).*firewall update work could not be accepted/,
+    /DNS answers withheld while firewall updates were unavailable \| `2`/,
   );
   const summary = summaryLines(report, dnsEvidence).join("\n");
-  assert.match(summary, /^### Fence Summary/);
+  assert.match(summary, /^### 🟡 Fence Summary/);
   assert.doesNotMatch(summary, /🟢/);
-  assert.match(summary, /Some DNS answers were withheld/);
-  assert.doesNotMatch(summary, /critical issue/);
+  assert.match(summary, /#### Warnings/);
+  assert.match(summary, /DNS answers withheld while firewall updates were unavailable/);
+  assert.doesNotMatch(summary, /Critical findings/);
 });
 
 test("renders bounded allowlist YAML snippets", () => {


### PR DESCRIPTION
## 🔍 TL;DR

Replace the prose-heavy job summary with compact result tables for Fence controls and observed network activity.

## 🧾 Details

The summary now shows mode, outbound-network enforcement, sudo and container status, and bounded destination decisions with activity counts. Audit allowlist guidance stays collapsed, while warnings and critical findings appear only when relevant.
