### PR TITLE
Release Fence 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "fence"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "clap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fence"
-version = "0.1.8"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.96.0"
 


### PR DESCRIPTION
Bump the source agent to `0.2.0` so the merged critical-adoption hardening can be published as an attested Linux x64 release.