### PR TITLE
Release v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "fence"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fence"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.96.0"
 


### PR DESCRIPTION
Publish Fence `v0.3.0` with the results-storage provenance hardening and versioned schema updates from PR #80.
