### PR TITLE
Validate effective Action mount evidence

### DIFF
--- a/.github/workflows/action-acceptance.yml
+++ b/.github/workflows/action-acceptance.yml
@@ -102,6 +102,40 @@ jobs:
       - name: verify zero-input Action lifecycle
         run: script/test-action-acceptance standard "fence-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
 
+  nested-layout:
+    name: action nested registered path
+    timeout-minutes: 8
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: checkout into nested Action path
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
+        with:
+          path: target/action-layout/owner/project/revision
+          persist-credentials: false
+
+      - name: validate locks
+        working-directory: target/action-layout/owner/project/revision
+        run: script/validate-locks --ci
+
+      - name: observe hosted runner fingerprint candidate
+        working-directory: target/action-layout/owner/project/revision
+        run: script/observe-hosted-runner
+
+      - name: test Action wrapper
+        working-directory: target/action-layout/owner/project/revision
+        run: script/test-action-wrapper
+
+      - name: activate bundled Fence agent from nested path
+        uses: ./target/action-layout/owner/project/revision
+        with:
+          mode: audit
+          invocation_id: action-nested-layout
+
+      - name: verify nested Action lifecycle
+        working-directory: target/action-layout/owner/project/revision
+        run: script/test-action-acceptance audit action-nested-layout
+
   setup-failure:
     name: action setup failure evidence
     timeout-minutes: 5
@@ -199,7 +233,7 @@ jobs:
 
   acceptance:
     name: action acceptance
-    needs: [action, zero-input, setup-failure, tamper, verify-action-finalization]
+    needs: [action, zero-input, nested-layout, setup-failure, tamper, verify-action-finalization]
     if: ${{ always() && !cancelled() }}
     runs-on: ubuntu-24.04
 
@@ -208,6 +242,7 @@ jobs:
         env:
           ACTION_RESULT: ${{ needs.action.result }}
           ZERO_INPUT_RESULT: ${{ needs.zero-input.result }}
+          NESTED_LAYOUT_RESULT: ${{ needs.nested-layout.result }}
           SETUP_FAILURE_RESULT: ${{ needs.setup-failure.result }}
           TAMPER_RESULT: ${{ needs.tamper.result }}
           FINALIZATION_RESULT: ${{ needs.verify-action-finalization.result }}
@@ -215,6 +250,7 @@ jobs:
           for result in \
             "$ACTION_RESULT" \
             "$ZERO_INPUT_RESULT" \
+            "$NESTED_LAYOUT_RESULT" \
             "$SETUP_FAILURE_RESULT" \
             "$TAMPER_RESULT" \
             "$FINALIZATION_RESULT"

--- a/action/lib.cts
+++ b/action/lib.cts
@@ -737,12 +737,20 @@ function validateProtectedActionRuntime(actionRoot: string): void {
   }
 }
 
-function validateReadOnlyActionMount(raw: unknown, expectedTarget: string): void {
-  const mount = effectiveActionMount(raw, expectedTarget, "protected Action");
+function validateReadOnlyActionMount(
+  raw: unknown,
+  expectedTarget: string,
+  expectedMountId: string,
+): void {
+  const mount = effectiveActionMount(
+    raw,
+    expectedTarget,
+    expectedMountId,
+    "protected Action",
+  );
   const options = new Set(mount.options.split(","));
   if (
     !options.has("ro") ||
-    options.has("rw") ||
     !options.has("nodev") ||
     !options.has("nosuid")
   ) {
@@ -750,23 +758,37 @@ function validateReadOnlyActionMount(raw: unknown, expectedTarget: string): void
   }
 }
 
-function mountIdentifier(value: unknown, allowZero: boolean): string | undefined {
+function mountIdentifier(value: unknown): string | undefined {
   const identifier = typeof value === "number" && Number.isSafeInteger(value)
     ? String(value)
     : value;
   if (
     typeof identifier !== "string" ||
-    !/^(0|[1-9][0-9]*)$/.test(identifier) ||
-    (!allowZero && identifier === "0")
+    !/^[1-9][0-9]*$/.test(identifier)
   ) {
     return undefined;
   }
   return identifier;
 }
 
+function mountIdFromFdInfo(raw: unknown): string {
+  if (typeof raw !== "string" || Buffer.byteLength(raw, "utf8") > 4 * 1024) {
+    fail("Fence active mount identity is unavailable");
+  }
+  const mountIds = raw
+    .split("\n")
+    .map((line) => /^mnt_id:\s+([1-9][0-9]*)\s*$/.exec(line)?.[1])
+    .filter((mountId): mountId is string => mountId !== undefined);
+  if (mountIds.length !== 1) {
+    fail("Fence active mount identity is unavailable");
+  }
+  return mountIds[0];
+}
+
 function effectiveActionMount(
   raw: unknown,
   expectedTarget: string,
+  expectedMountId: string,
   description: string,
 ): { options: string } {
   if (typeof raw !== "string" || Buffer.byteLength(raw, "utf8") > 16 * 1024) {
@@ -783,45 +805,40 @@ function effectiveActionMount(
     Array.isArray(document) ||
     typeof document !== "object" ||
     !Array.isArray(document.filesystems) ||
-    document.filesystems.length === 0
+    document.filesystems.length !== 1
   ) {
     fail(`Fence ${description} mount evidence is incomplete`);
   }
-  const mounts = document.filesystems.map((mount: any) => {
-    const id = mountIdentifier(mount?.id, false);
-    const parent = mountIdentifier(mount?.parent, true);
-    if (
-      mount === null ||
-      Array.isArray(mount) ||
-      typeof mount !== "object" ||
-      Object.keys(mount).sort().join(",") !== "id,options,parent,target" ||
-      typeof mount.options !== "string" ||
-      id === undefined ||
-      parent === undefined
-    ) {
-      fail(`Fence ${description} mount evidence is incomplete`);
-    }
-    if (mount.target !== expectedTarget) {
-      fail(`Fence ${description} mount does not match the registered runtime`);
-    }
-    return { id, parent, options: mount.options };
-  });
-
-  const mountIds = new Set(mounts.map((mount) => mount.id));
-  if (mountIds.size !== mounts.length) {
+  const mount = document.filesystems[0];
+  const mountId = mountIdentifier(mount?.id);
+  if (
+    mount === null ||
+    Array.isArray(mount) ||
+    typeof mount !== "object" ||
+    Object.keys(mount).sort().join(",") !== "id,options,target" ||
+    typeof mount.options !== "string" ||
+    mountId === undefined ||
+    mountIdentifier(expectedMountId) !== expectedMountId
+  ) {
     fail(`Fence ${description} mount evidence is incomplete`);
   }
-  // In a same-target mount stack, every hidden layer is the parent of a newer layer.
-  const parentIds = new Set(mounts.map((mount) => mount.parent));
-  const effective = mounts.filter((mount) => !parentIds.has(mount.id));
-  if (effective.length !== 1) {
-    fail(`Fence ${description} mount evidence is incomplete`);
+  if (mount.target !== expectedTarget || mountId !== expectedMountId) {
+    fail(`Fence ${description} mount does not match the active runtime`);
   }
-  return effective[0];
+  return mount;
 }
 
-function validateActionPathGuardMount(raw: unknown, expectedTarget: string): void {
-  const mount = effectiveActionMount(raw, expectedTarget, "registered Action path guard");
+function validateActionPathGuardMount(
+  raw: unknown,
+  expectedTarget: string,
+  expectedMountId: string,
+): void {
+  const mount = effectiveActionMount(
+    raw,
+    expectedTarget,
+    expectedMountId,
+    "registered Action path guard",
+  );
   const options = new Set(mount.options.split(","));
   if (!options.has("rw") || options.has("ro")) {
     fail("Fence registered Action path guard mount must remain writable");
@@ -1803,6 +1820,7 @@ module.exports = {
   materializationRequestRejections,
   materializationEvidenceCounter,
   materializationWarningLines,
+  mountIdFromFdInfo,
   networkActivitySummary,
   nativeInputsFromEnvironment,
   readJsonBounded,

--- a/action/lib.cts
+++ b/action/lib.cts
@@ -738,74 +738,92 @@ function validateProtectedActionRuntime(actionRoot: string): void {
 }
 
 function validateReadOnlyActionMount(raw: unknown, expectedTarget: string): void {
+  const mount = effectiveActionMount(raw, expectedTarget, "protected Action");
+  const options = new Set(mount.options.split(","));
+  if (
+    !options.has("ro") ||
+    options.has("rw") ||
+    !options.has("nodev") ||
+    !options.has("nosuid")
+  ) {
+    fail("Fence protected Action mount is missing required options");
+  }
+}
+
+function mountIdentifier(value: unknown, allowZero: boolean): string | undefined {
+  const identifier = typeof value === "number" && Number.isSafeInteger(value)
+    ? String(value)
+    : value;
+  if (
+    typeof identifier !== "string" ||
+    !/^(0|[1-9][0-9]*)$/.test(identifier) ||
+    (!allowZero && identifier === "0")
+  ) {
+    return undefined;
+  }
+  return identifier;
+}
+
+function effectiveActionMount(
+  raw: unknown,
+  expectedTarget: string,
+  description: string,
+): { options: string } {
   if (typeof raw !== "string" || Buffer.byteLength(raw, "utf8") > 16 * 1024) {
-    fail("Fence protected Action mount evidence is unavailable");
+    fail(`Fence ${description} mount evidence is unavailable`);
   }
   let document: any;
   try {
     document = JSON.parse(raw);
   } catch {
-    fail("Fence protected Action mount evidence is malformed");
+    fail(`Fence ${description} mount evidence is malformed`);
   }
   if (
     document === null ||
     Array.isArray(document) ||
     typeof document !== "object" ||
     !Array.isArray(document.filesystems) ||
-    document.filesystems.length !== 1
+    document.filesystems.length === 0
   ) {
-    fail("Fence protected Action mount evidence is incomplete");
+    fail(`Fence ${description} mount evidence is incomplete`);
   }
-  if (
-    document.filesystems.some((mount: any) =>
+  const mounts = document.filesystems.map((mount: any) => {
+    const id = mountIdentifier(mount?.id, false);
+    const parent = mountIdentifier(mount?.parent, true);
+    if (
       mount === null ||
       Array.isArray(mount) ||
       typeof mount !== "object" ||
-      mount.target !== expectedTarget ||
-      typeof mount.options !== "string"
-    )
-  ) {
-    fail("Fence protected Action mount does not match the registered runtime");
-  }
-  const requiredOptions = ["ro", "nodev", "nosuid"];
-  const hasProtectedMount = document.filesystems.some((mount: any) => {
-    const options = new Set(mount.options.split(","));
-    return requiredOptions.every((required) => options.has(required));
+      Object.keys(mount).sort().join(",") !== "id,options,parent,target" ||
+      typeof mount.options !== "string" ||
+      id === undefined ||
+      parent === undefined
+    ) {
+      fail(`Fence ${description} mount evidence is incomplete`);
+    }
+    if (mount.target !== expectedTarget) {
+      fail(`Fence ${description} mount does not match the registered runtime`);
+    }
+    return { id, parent, options: mount.options };
   });
-  if (!hasProtectedMount) {
-    fail("Fence protected Action mount is missing required options");
+
+  const mountIds = new Set(mounts.map((mount) => mount.id));
+  if (mountIds.size !== mounts.length) {
+    fail(`Fence ${description} mount evidence is incomplete`);
   }
+  // In a same-target mount stack, every hidden layer is the parent of a newer layer.
+  const parentIds = new Set(mounts.map((mount) => mount.parent));
+  const effective = mounts.filter((mount) => !parentIds.has(mount.id));
+  if (effective.length !== 1) {
+    fail(`Fence ${description} mount evidence is incomplete`);
+  }
+  return effective[0];
 }
 
 function validateActionPathGuardMount(raw: unknown, expectedTarget: string): void {
-  if (typeof raw !== "string" || Buffer.byteLength(raw, "utf8") > 16 * 1024) {
-    fail("Fence registered Action path guard mount evidence is unavailable");
-  }
-  let document: any;
-  try {
-    document = JSON.parse(raw);
-  } catch {
-    fail("Fence registered Action path guard mount evidence is malformed");
-  }
-  const mounts = document?.filesystems;
-  if (
-    !Array.isArray(mounts) ||
-    mounts.length !== 1 ||
-    mounts.some((mount) =>
-      mount === null ||
-      Array.isArray(mount) ||
-      typeof mount !== "object" ||
-      mount.target !== expectedTarget ||
-      typeof mount.options !== "string"
-    )
-  ) {
-    fail("Fence registered Action path guard mount does not match the protected runtime");
-  }
-  const hasWritableMount = mounts.some((mount) => {
-    const options = new Set(mount.options.split(","));
-    return options.has("rw") && !options.has("ro");
-  });
-  if (!hasWritableMount) {
+  const mount = effectiveActionMount(raw, expectedTarget, "registered Action path guard");
+  const options = new Set(mount.options.split(","));
+  if (!options.has("rw") || options.has("ro")) {
     fail("Fence registered Action path guard mount must remain writable");
   }
 }

--- a/action/lib.cts
+++ b/action/lib.cts
@@ -752,8 +752,7 @@ function validateReadOnlyActionMount(raw: unknown, expectedTarget: string): void
     Array.isArray(document) ||
     typeof document !== "object" ||
     !Array.isArray(document.filesystems) ||
-    document.filesystems.length === 0 ||
-    document.filesystems.length > MAX_ACTION_PATH_GUARDS
+    document.filesystems.length !== 1
   ) {
     fail("Fence protected Action mount evidence is incomplete");
   }
@@ -791,8 +790,7 @@ function validateActionPathGuardMount(raw: unknown, expectedTarget: string): voi
   const mounts = document?.filesystems;
   if (
     !Array.isArray(mounts) ||
-    mounts.length === 0 ||
-    mounts.length > MAX_ACTION_PATH_GUARDS ||
+    mounts.length !== 1 ||
     mounts.some((mount) =>
       mount === null ||
       Array.isArray(mount) ||

--- a/action/lib.cts
+++ b/action/lib.cts
@@ -791,6 +791,9 @@ function effectiveActionMount(
   expectedMountId: string,
   description: string,
 ): { options: string } {
+  if (mountIdentifier(expectedMountId) !== expectedMountId) {
+    fail(`Fence ${description} mount evidence is incomplete`);
+  }
   if (typeof raw !== "string" || Buffer.byteLength(raw, "utf8") > 16 * 1024) {
     fail(`Fence ${description} mount evidence is unavailable`);
   }
@@ -805,27 +808,35 @@ function effectiveActionMount(
     Array.isArray(document) ||
     typeof document !== "object" ||
     !Array.isArray(document.filesystems) ||
-    document.filesystems.length !== 1
+    document.filesystems.length === 0
   ) {
     fail(`Fence ${description} mount evidence is incomplete`);
   }
-  const mount = document.filesystems[0];
-  const mountId = mountIdentifier(mount?.id);
-  if (
-    mount === null ||
-    Array.isArray(mount) ||
-    typeof mount !== "object" ||
-    Object.keys(mount).sort().join(",") !== "id,options,target" ||
-    typeof mount.options !== "string" ||
-    mountId === undefined ||
-    mountIdentifier(expectedMountId) !== expectedMountId
-  ) {
+  const mounts = document.filesystems.map((mount: any) => {
+    const mountId = mountIdentifier(mount?.id);
+    if (
+      mount === null ||
+      Array.isArray(mount) ||
+      typeof mount !== "object" ||
+      Object.keys(mount).sort().join(",") !== "id,options,target" ||
+      typeof mount.options !== "string" ||
+      mountId === undefined
+    ) {
+      fail(`Fence ${description} mount evidence is incomplete`);
+    }
+    if (mount.target !== expectedTarget) {
+      fail(`Fence ${description} mount does not match the registered runtime`);
+    }
+    return { id: mountId, options: mount.options };
+  });
+  if (new Set(mounts.map((mount) => mount.id)).size !== mounts.length) {
     fail(`Fence ${description} mount evidence is incomplete`);
   }
-  if (mount.target !== expectedTarget || mountId !== expectedMountId) {
+  const activeMounts = mounts.filter((mount) => mount.id === expectedMountId);
+  if (activeMounts.length !== 1) {
     fail(`Fence ${description} mount does not match the active runtime`);
   }
-  return mount;
+  return activeMounts[0];
 }
 
 function validateActionPathGuardMount(

--- a/action/lib.cts
+++ b/action/lib.cts
@@ -127,6 +127,8 @@ const ACTION_RUNTIME_FILES = [
 const MAX_ACTION_RUNTIME_FILE_BYTES = 64 * 1024 * 1024;
 const MAX_ACTION_PATH_GUARDS = 16;
 const MAX_ACTION_PATH_ANCESTORS = 64;
+const MAX_ACTION_MOUNTINFO_BYTES = 4 * 1024 * 1024;
+const MAX_ACTION_MOUNTINFO_RECORD_BYTES = 16 * 1024;
 const REPORT_STATUSES = new Set([
   "protected_host_block",
   "protected_host_block_degraded",
@@ -783,6 +785,120 @@ function mountIdFromFdInfo(raw: unknown): string {
     fail("Fence active mount identity is unavailable");
   }
   return mountIds[0];
+}
+
+function mountInfoRecordForId(mountId: string): string {
+  const descriptor = fs.openSync(
+    "/proc/self/mountinfo",
+    fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW,
+  );
+  try {
+    const chunks: Buffer[] = [];
+    const chunk = Buffer.alloc(16 * 1024);
+    let totalBytes = 0;
+    while (true) {
+      const bytesRead = fs.readSync(descriptor, chunk, 0, chunk.length, null);
+      if (bytesRead === 0) {
+        break;
+      }
+      totalBytes += bytesRead;
+      if (totalBytes > MAX_ACTION_MOUNTINFO_BYTES) {
+        fail("Fence active mount table is unavailable");
+      }
+      chunks.push(Buffer.from(chunk.subarray(0, bytesRead)));
+    }
+    const matching = Buffer.concat(chunks, totalBytes)
+      .toString("utf8")
+      .split("\n")
+      .filter((line) => line.startsWith(`${mountId} `));
+    if (matching.length !== 1) {
+      fail("Fence active mount table is unavailable");
+    }
+    return matching[0];
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+function decodeMountInfoPath(encoded: string): string {
+  if (encoded.replace(/\\(?:011|012|040|134)/g, "").includes("\\")) {
+    fail("Fence active mount record is malformed");
+  }
+  return encoded.replace(
+    /\\(011|012|040|134)/g,
+    (_escape, octal) => String.fromCharCode(Number.parseInt(octal, 8)),
+  );
+}
+
+function actionMountRecordFromMountInfo(
+  raw: unknown,
+  expectedTarget: string,
+  expectedMountId: string,
+): { target: string; options: string; id: string } {
+  if (
+    typeof raw !== "string" ||
+    Buffer.byteLength(raw, "utf8") > MAX_ACTION_MOUNTINFO_RECORD_BYTES ||
+    raw.length === 0 ||
+    raw.includes("\n") ||
+    raw.includes("\r")
+  ) {
+    fail("Fence active mount record is unavailable");
+  }
+  const fields = raw.split(" ");
+  const separator = fields.indexOf("-", 6);
+  const mountId = mountIdentifier(fields[0]);
+  if (
+    mountId === undefined ||
+    mountId !== expectedMountId ||
+    !/^[0-9]+:[0-9]+$/.test(fields[2] || "") ||
+    separator < 6 ||
+    fields.length < separator + 4 ||
+    !fields[5]
+  ) {
+    fail("Fence active mount record is malformed");
+  }
+  const target = decodeMountInfoPath(fields[4]);
+  if (target !== expectedTarget) {
+    fail("Fence active mount record does not match the registered runtime");
+  }
+  return { target, options: fields[5], id: mountId };
+}
+
+function activeActionMountEvidence(
+  target: string,
+): { raw: string; mountId: string } {
+  if (!path.isAbsolute(target) || path.normalize(target) !== target) {
+    fail("Fence active Action mount target is invalid");
+  }
+  let descriptor: number;
+  try {
+    descriptor = fs.openSync(
+      target,
+      fs.constants.O_RDONLY |
+        fs.constants.O_DIRECTORY |
+        fs.constants.O_NOFOLLOW,
+    );
+  } catch {
+    fail("Fence active Action mount evidence is unavailable");
+  }
+  try {
+    const mountId = mountIdFromFdInfo(
+      fs.readFileSync(`/proc/self/fdinfo/${descriptor}`, "utf8"),
+    );
+    const record = actionMountRecordFromMountInfo(
+      mountInfoRecordForId(mountId),
+      target,
+      mountId,
+    );
+    return {
+      raw: JSON.stringify({ filesystems: [record] }),
+      mountId,
+    };
+  } catch {
+    fail("Fence active Action mount evidence is unavailable");
+  } finally {
+    fs.closeSync(descriptor);
+  }
 }
 
 function effectiveActionMount(
@@ -1820,6 +1936,8 @@ function summaryLines(report: any, dnsEvidence: any = undefined): string[] {
 module.exports = {
   ACTION_RUNTIME_FILES,
   MAX_REPORT_BYTES,
+  activeActionMountEvidence,
+  actionMountRecordFromMountInfo,
   actionPathGuardIdentities,
   actionRuntimeDigest,
   actionRuntimeFileDigests,

--- a/action/main.cts
+++ b/action/main.cts
@@ -202,13 +202,11 @@ function createOrValidateRootDirectory(directory: string): void {
 function mountEvidence(actionRoot: string): string {
   return captureRequired("/usr/bin/findmnt", [
     "--json",
-    "--direction",
-    "backward",
-    "--first-only",
+    "--list",
     "--mountpoint",
     actionRoot,
     "--output",
-    "TARGET,OPTIONS",
+    "TARGET,OPTIONS,ID,PARENT",
   ]);
 }
 

--- a/action/main.cts
+++ b/action/main.cts
@@ -7,11 +7,11 @@ const log = require("./log.cts");
 const {
   ACTION_RUNTIME_FILES,
   MAX_REPORT_BYTES,
+  activeActionMountEvidence,
   actionPathGuardIdentities,
   actionRuntimeDigest,
   actionRuntimeFileDigests,
   launcherIntegrityDocument,
-  mountIdFromFdInfo,
   nativeInputsFromEnvironment,
   readJsonBounded,
   readLauncherIntegrity,
@@ -97,14 +97,6 @@ function capture(
     stderr: String(result.stderr || ""),
     error: result.error ? result.error.message : undefined,
   };
-}
-
-function captureRequired(executable: string, args: string[]): string {
-  const result = capture(executable, args);
-  if (result.error || result.status !== 0) {
-    throw new Error(`${path.basename(executable)} could not verify protected Action state`);
-  }
-  return result.stdout;
 }
 
 function compactServiceStatus(output: string): string {
@@ -200,41 +192,6 @@ function createOrValidateRootDirectory(directory: string): void {
   assertRootDirectory(directory);
 }
 
-function mountEvidence(actionRoot: string): { raw: string; mountId: string } {
-  let descriptor: number;
-  try {
-    descriptor = fs.openSync(
-      actionRoot,
-      fs.constants.O_RDONLY |
-        fs.constants.O_DIRECTORY |
-        fs.constants.O_NOFOLLOW,
-    );
-  } catch {
-    throw new Error("Fence active Action mount could not be opened");
-  }
-  try {
-    let mountId: string;
-    try {
-      mountId = mountIdFromFdInfo(
-        fs.readFileSync(`/proc/self/fdinfo/${descriptor}`, "utf8"),
-      );
-    } catch {
-      throw new Error("Fence active Action mount could not be identified");
-    }
-    const raw = captureRequired("/usr/bin/findmnt", [
-      "--json",
-      "--list",
-      "--mountpoint",
-      actionRoot,
-      "--output",
-      "TARGET,OPTIONS,ID",
-    ]);
-    return { raw, mountId };
-  } finally {
-    fs.closeSync(descriptor);
-  }
-}
-
 function installProtectedActionRuntime(
   invocationId: string,
   paths: ReturnType<typeof runtimePaths>,
@@ -321,7 +278,7 @@ function installProtectedActionRuntime(
       guard.path,
     ]);
     protectedActionPathGuards.push(guard.path);
-    const evidence = mountEvidence(guard.path);
+    const evidence = activeActionMountEvidence(guard.path);
     validateActionPathGuardMount(evidence.raw, guard.path, evidence.mountId);
   }
 
@@ -339,7 +296,7 @@ function installProtectedActionRuntime(
     paths.launcherActionDirectory,
     ACTION_ROOT,
   ]);
-  const actionMount = mountEvidence(ACTION_ROOT);
+  const actionMount = activeActionMountEvidence(ACTION_ROOT);
   validateReadOnlyActionMount(actionMount.raw, ACTION_ROOT, actionMount.mountId);
   validateProtectedActionRuntime(ACTION_ROOT);
   const mountedFiles = actionRuntimeFileDigests(ACTION_ROOT);
@@ -353,7 +310,7 @@ function installProtectedActionRuntime(
     mountedPathGuards,
   );
   for (const guard of mountedPathGuards) {
-    const evidence = mountEvidence(guard.path);
+    const evidence = activeActionMountEvidence(guard.path);
     validateActionPathGuardMount(evidence.raw, guard.path, evidence.mountId);
   }
   validateBundle(MANIFEST, BINARY);

--- a/action/main.cts
+++ b/action/main.cts
@@ -224,8 +224,8 @@ function mountEvidence(actionRoot: string): { raw: string; mountId: string } {
     const raw = captureRequired("/usr/bin/findmnt", [
       "--json",
       "--list",
-      "--id",
-      mountId,
+      "--mountpoint",
+      actionRoot,
       "--output",
       "TARGET,OPTIONS,ID",
     ]);

--- a/action/main.cts
+++ b/action/main.cts
@@ -202,7 +202,9 @@ function createOrValidateRootDirectory(directory: string): void {
 function mountEvidence(actionRoot: string): string {
   return captureRequired("/usr/bin/findmnt", [
     "--json",
-    "--uniq",
+    "--direction",
+    "backward",
+    "--first-only",
     "--mountpoint",
     actionRoot,
     "--output",

--- a/action/main.cts
+++ b/action/main.cts
@@ -11,6 +11,7 @@ const {
   actionRuntimeDigest,
   actionRuntimeFileDigests,
   launcherIntegrityDocument,
+  mountIdFromFdInfo,
   nativeInputsFromEnvironment,
   readJsonBounded,
   readLauncherIntegrity,
@@ -199,15 +200,39 @@ function createOrValidateRootDirectory(directory: string): void {
   assertRootDirectory(directory);
 }
 
-function mountEvidence(actionRoot: string): string {
-  return captureRequired("/usr/bin/findmnt", [
-    "--json",
-    "--list",
-    "--mountpoint",
-    actionRoot,
-    "--output",
-    "TARGET,OPTIONS,ID,PARENT",
-  ]);
+function mountEvidence(actionRoot: string): { raw: string; mountId: string } {
+  let descriptor: number;
+  try {
+    descriptor = fs.openSync(
+      actionRoot,
+      fs.constants.O_RDONLY |
+        fs.constants.O_DIRECTORY |
+        fs.constants.O_NOFOLLOW,
+    );
+  } catch {
+    throw new Error("Fence active Action mount could not be opened");
+  }
+  try {
+    let mountId: string;
+    try {
+      mountId = mountIdFromFdInfo(
+        fs.readFileSync(`/proc/self/fdinfo/${descriptor}`, "utf8"),
+      );
+    } catch {
+      throw new Error("Fence active Action mount could not be identified");
+    }
+    const raw = captureRequired("/usr/bin/findmnt", [
+      "--json",
+      "--list",
+      "--id",
+      mountId,
+      "--output",
+      "TARGET,OPTIONS,ID",
+    ]);
+    return { raw, mountId };
+  } finally {
+    fs.closeSync(descriptor);
+  }
 }
 
 function installProtectedActionRuntime(
@@ -296,7 +321,8 @@ function installProtectedActionRuntime(
       guard.path,
     ]);
     protectedActionPathGuards.push(guard.path);
-    validateActionPathGuardMount(mountEvidence(guard.path), guard.path);
+    const evidence = mountEvidence(guard.path);
+    validateActionPathGuardMount(evidence.raw, guard.path, evidence.mountId);
   }
 
   run("/usr/bin/sudo", [
@@ -313,7 +339,8 @@ function installProtectedActionRuntime(
     paths.launcherActionDirectory,
     ACTION_ROOT,
   ]);
-  validateReadOnlyActionMount(mountEvidence(ACTION_ROOT), ACTION_ROOT);
+  const actionMount = mountEvidence(ACTION_ROOT);
+  validateReadOnlyActionMount(actionMount.raw, ACTION_ROOT, actionMount.mountId);
   validateProtectedActionRuntime(ACTION_ROOT);
   const mountedFiles = actionRuntimeFileDigests(ACTION_ROOT);
   const mountedPathGuards = actionPathGuardIdentities(ACTION_ROOT);
@@ -326,7 +353,8 @@ function installProtectedActionRuntime(
     mountedPathGuards,
   );
   for (const guard of mountedPathGuards) {
-    validateActionPathGuardMount(mountEvidence(guard.path), guard.path);
+    const evidence = mountEvidence(guard.path);
+    validateActionPathGuardMount(evidence.raw, guard.path, evidence.mountId);
   }
   validateBundle(MANIFEST, BINARY);
   log.debugGroup("Fence debug: protected Action runtime", [

--- a/action/main.cts
+++ b/action/main.cts
@@ -202,6 +202,7 @@ function createOrValidateRootDirectory(directory: string): void {
 function mountEvidence(actionRoot: string): string {
   return captureRequired("/usr/bin/findmnt", [
     "--json",
+    "--uniq",
     "--mountpoint",
     actionRoot,
     "--output",

--- a/action/post.cts
+++ b/action/post.cts
@@ -101,7 +101,7 @@ function captureMountEvidence(
     }
     const result = spawnSync(
       "/usr/bin/findmnt",
-      ["--json", "--list", "--id", mountId, "--output", "TARGET,OPTIONS,ID"],
+      ["--json", "--list", "--mountpoint", target, "--output", "TARGET,OPTIONS,ID"],
       {
         encoding: "utf8",
         env: CHILD_ENV,

--- a/action/post.cts
+++ b/action/post.cts
@@ -74,7 +74,7 @@ function validateProtectedActionMount(actionRoot: string): void {
 function captureMountEvidence(target: string, failureMessage: string): string {
   const result = spawnSync(
     "/usr/bin/findmnt",
-    ["--json", "--mountpoint", target, "--output", "TARGET,OPTIONS"],
+    ["--json", "--uniq", "--mountpoint", target, "--output", "TARGET,OPTIONS"],
     {
       encoding: "utf8",
       env: CHILD_ENV,

--- a/action/post.cts
+++ b/action/post.cts
@@ -74,7 +74,16 @@ function validateProtectedActionMount(actionRoot: string): void {
 function captureMountEvidence(target: string, failureMessage: string): string {
   const result = spawnSync(
     "/usr/bin/findmnt",
-    ["--json", "--uniq", "--mountpoint", target, "--output", "TARGET,OPTIONS"],
+    [
+      "--json",
+      "--direction",
+      "backward",
+      "--first-only",
+      "--mountpoint",
+      target,
+      "--output",
+      "TARGET,OPTIONS",
+    ],
     {
       encoding: "utf8",
       env: CHILD_ENV,

--- a/action/post.cts
+++ b/action/post.cts
@@ -5,13 +5,13 @@ const path = require("node:path");
 const { spawnSync } = require("node:child_process");
 const log = require("./log.cts");
 const {
+  activeActionMountEvidence,
   actionPathGuardIdentities,
   actionRuntimeFileDigests,
   correlateFindingsToDns,
   findingAttributionDebugLines,
   materializationRequestRejections,
   materializationEvidenceCounter,
-  mountIdFromFdInfo,
   MAX_REPORT_BYTES,
   readJsonBounded,
   readLauncherIntegrity,
@@ -68,65 +68,14 @@ function validateResidentService(unit: string, expectedPid: unknown): void {
 }
 
 function validateProtectedActionMount(actionRoot: string): void {
-  const evidence = captureMountEvidence(
-    actionRoot,
-    "Fence protected Action mount could not be verified",
-  );
+  const evidence = activeActionMountEvidence(actionRoot);
   validateReadOnlyActionMount(evidence.raw, actionRoot, evidence.mountId);
-}
-
-function captureMountEvidence(
-  target: string,
-  failureMessage: string,
-): { raw: string; mountId: string } {
-  let descriptor: number;
-  try {
-    descriptor = fs.openSync(
-      target,
-      fs.constants.O_RDONLY |
-        fs.constants.O_DIRECTORY |
-        fs.constants.O_NOFOLLOW,
-    );
-  } catch {
-    throw new Error(failureMessage);
-  }
-  try {
-    let mountId: string;
-    try {
-      mountId = mountIdFromFdInfo(
-        fs.readFileSync(`/proc/self/fdinfo/${descriptor}`, "utf8"),
-      );
-    } catch {
-      throw new Error(failureMessage);
-    }
-    const result = spawnSync(
-      "/usr/bin/findmnt",
-      ["--json", "--list", "--mountpoint", target, "--output", "TARGET,OPTIONS,ID"],
-      {
-        encoding: "utf8",
-        env: CHILD_ENV,
-        killSignal: "SIGKILL",
-        maxBuffer: 16 * 1024,
-        stdio: ["ignore", "pipe", "pipe"],
-        timeout: 2 * 1000,
-      },
-    );
-    if (result.error || result.status !== 0 || String(result.stderr || "").length !== 0) {
-      throw new Error(failureMessage);
-    }
-    return { raw: String(result.stdout || ""), mountId };
-  } finally {
-    fs.closeSync(descriptor);
-  }
 }
 
 function validateRegisteredActionPathGuards(actionRoot: string): ReturnType<typeof actionPathGuardIdentities> {
   const guards = actionPathGuardIdentities(actionRoot);
   for (const guard of guards) {
-    const evidence = captureMountEvidence(
-      guard.path,
-      "Fence registered Action path guard could not be verified",
-    );
+    const evidence = activeActionMountEvidence(guard.path);
     validateActionPathGuardMount(evidence.raw, guard.path, evidence.mountId);
   }
   return guards;

--- a/action/post.cts
+++ b/action/post.cts
@@ -76,13 +76,11 @@ function captureMountEvidence(target: string, failureMessage: string): string {
     "/usr/bin/findmnt",
     [
       "--json",
-      "--direction",
-      "backward",
-      "--first-only",
+      "--list",
       "--mountpoint",
       target,
       "--output",
-      "TARGET,OPTIONS",
+      "TARGET,OPTIONS,ID,PARENT",
     ],
     {
       encoding: "utf8",

--- a/action/post.cts
+++ b/action/post.cts
@@ -11,6 +11,7 @@ const {
   findingAttributionDebugLines,
   materializationRequestRejections,
   materializationEvidenceCounter,
+  mountIdFromFdInfo,
   MAX_REPORT_BYTES,
   readJsonBounded,
   readLauncherIntegrity,
@@ -67,44 +68,66 @@ function validateResidentService(unit: string, expectedPid: unknown): void {
 }
 
 function validateProtectedActionMount(actionRoot: string): void {
-  const raw = captureMountEvidence(actionRoot, "Fence protected Action mount could not be verified");
-  validateReadOnlyActionMount(raw, actionRoot);
+  const evidence = captureMountEvidence(
+    actionRoot,
+    "Fence protected Action mount could not be verified",
+  );
+  validateReadOnlyActionMount(evidence.raw, actionRoot, evidence.mountId);
 }
 
-function captureMountEvidence(target: string, failureMessage: string): string {
-  const result = spawnSync(
-    "/usr/bin/findmnt",
-    [
-      "--json",
-      "--list",
-      "--mountpoint",
+function captureMountEvidence(
+  target: string,
+  failureMessage: string,
+): { raw: string; mountId: string } {
+  let descriptor: number;
+  try {
+    descriptor = fs.openSync(
       target,
-      "--output",
-      "TARGET,OPTIONS,ID,PARENT",
-    ],
-    {
-      encoding: "utf8",
-      env: CHILD_ENV,
-      killSignal: "SIGKILL",
-      maxBuffer: 16 * 1024,
-      stdio: ["ignore", "pipe", "pipe"],
-      timeout: 2 * 1000,
-    },
-  );
-  if (result.error || result.status !== 0 || String(result.stderr || "").length !== 0) {
+      fs.constants.O_RDONLY |
+        fs.constants.O_DIRECTORY |
+        fs.constants.O_NOFOLLOW,
+    );
+  } catch {
     throw new Error(failureMessage);
   }
-  return String(result.stdout || "");
+  try {
+    let mountId: string;
+    try {
+      mountId = mountIdFromFdInfo(
+        fs.readFileSync(`/proc/self/fdinfo/${descriptor}`, "utf8"),
+      );
+    } catch {
+      throw new Error(failureMessage);
+    }
+    const result = spawnSync(
+      "/usr/bin/findmnt",
+      ["--json", "--list", "--id", mountId, "--output", "TARGET,OPTIONS,ID"],
+      {
+        encoding: "utf8",
+        env: CHILD_ENV,
+        killSignal: "SIGKILL",
+        maxBuffer: 16 * 1024,
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: 2 * 1000,
+      },
+    );
+    if (result.error || result.status !== 0 || String(result.stderr || "").length !== 0) {
+      throw new Error(failureMessage);
+    }
+    return { raw: String(result.stdout || ""), mountId };
+  } finally {
+    fs.closeSync(descriptor);
+  }
 }
 
 function validateRegisteredActionPathGuards(actionRoot: string): ReturnType<typeof actionPathGuardIdentities> {
   const guards = actionPathGuardIdentities(actionRoot);
   for (const guard of guards) {
-    const raw = captureMountEvidence(
+    const evidence = captureMountEvidence(
       guard.path,
       "Fence registered Action path guard could not be verified",
     );
-    validateActionPathGuardMount(raw, guard.path);
+    validateActionPathGuardMount(evidence.raw, guard.path, evidence.mountId);
   }
   return guards;
 }

--- a/action/test.cts
+++ b/action/test.cts
@@ -583,6 +583,12 @@ test("requires the active registered Action runtime mount to be read-only, nodev
   validateReadOnlyActionMount(JSON.stringify({
     filesystems: [{ target, options: "ro,nosuid,nodev,relatime", id: 10 }],
   }), target, mountId);
+  const stacked = Array.from({ length: 24 }, (_, index) => ({
+    target,
+    options: index === 23 ? "ro,nosuid,nodev,relatime" : "rw,relatime",
+    id: 10 + index,
+  }));
+  validateReadOnlyActionMount(JSON.stringify({ filesystems: stacked }), target, "33");
 
   for (const options of ["rw,nosuid,nodev", "ro,nodev", "ro,nosuid"]) {
     assert.throws(
@@ -604,7 +610,7 @@ test("requires the active registered Action runtime mount to be read-only, nodev
   for (const filesystems of [
     [
       { target, options: "ro,nosuid,nodev", id: 10 },
-      { target, options: "ro,nosuid,nodev", id: 11 },
+      { target, options: "ro,nosuid,nodev", id: 10 },
     ],
     [{ target, options: "ro,nosuid,nodev", id: 10, parent: 1 }],
     [{ target, options: "ro,nosuid,nodev" }],
@@ -615,6 +621,15 @@ test("requires the active registered Action runtime mount to be read-only, nodev
       /incomplete/,
     );
   }
+  assert.throws(
+    () => validateReadOnlyActionMount(JSON.stringify({
+      filesystems: [
+        { target, options: "ro,nosuid,nodev", id: 10 },
+        { target, options: "rw,nosuid,nodev", id: 11 },
+      ],
+    }), target, "11"),
+    /missing/,
+  );
   assert.throws(
     () => validateReadOnlyActionMount(JSON.stringify({
       filesystems: [{ target, options: "ro,nosuid,nodev", id: 10 }],
@@ -630,6 +645,12 @@ test("requires active registered Action path guards to remain exact writable mou
   validateActionPathGuardMount(JSON.stringify({
     filesystems: [{ target, options: "rw,nosuid,nodev,relatime", id: mountId }],
   }), target, mountId);
+  validateActionPathGuardMount(JSON.stringify({
+    filesystems: [
+      { target, options: "ro,nosuid,nodev", id: 9 },
+      { target, options: "rw,nosuid,nodev,relatime", id: 10 },
+    ],
+  }), target, mountId);
   for (const evidence of [
     { filesystems: [{ target, options: "ro,nosuid,nodev", id: 10 }] },
     { filesystems: [{ target, options: "rw,ro,nosuid,nodev", id: 10 }] },
@@ -638,7 +659,13 @@ test("requires active registered Action path guards to remain exact writable mou
     {
       filesystems: [
         { target, options: "rw,nosuid,nodev", id: 10 },
-        { target, options: "rw,nosuid,nodev", id: 11 },
+        { target, options: "rw,nosuid,nodev", id: 10 },
+      ],
+    },
+    {
+      filesystems: [
+        { target, options: "rw,nosuid,nodev", id: 9 },
+        { target, options: "ro,nosuid,nodev", id: 10 },
       ],
     },
     { filesystems: [{ target, options: "rw,nosuid,nodev", id: 10, parent: 1 }] },

--- a/action/test.cts
+++ b/action/test.cts
@@ -563,16 +563,10 @@ test("guards every renameable ancestor of the registered Action path", () => {
   }
 });
 
-test("requires the registered Action runtime mount to be read-only, nodev, and nosuid", () => {
+test("requires the effective registered Action runtime mount to be read-only, nodev, and nosuid", () => {
   const target = "/opt/actions/fence/action";
   validateReadOnlyActionMount(JSON.stringify({
     filesystems: [{ target, options: "ro,nosuid,nodev,relatime" }],
-  }), target);
-  validateReadOnlyActionMount(JSON.stringify({
-    filesystems: [
-      { target, options: "rw,nosuid,nodev,relatime" },
-      { target, options: "ro,nosuid,nodev,relatime" },
-    ],
   }), target);
   for (const options of ["rw,nosuid,nodev", "ro,nodev", "ro,nosuid"]) {
     assert.throws(
@@ -592,24 +586,18 @@ test("requires the registered Action runtime mount to be read-only, nodev, and n
     () => validateReadOnlyActionMount(JSON.stringify({
       filesystems: [
         { target, options: "ro,nosuid,nodev" },
-        { target: "/different", options: "ro,nosuid,nodev" },
+        { target, options: "ro,nosuid,nodev" },
       ],
     }), target),
-    /does not match/,
+    /incomplete/,
   );
   assert.throws(() => validateReadOnlyActionMount("not-json", target), /malformed/);
 });
 
-test("requires registered Action path guards to remain exact writable mountpoints", () => {
+test("requires effective registered Action path guards to remain exact writable mountpoints", () => {
   const target = "/srv/runner/work/project";
   validateActionPathGuardMount(JSON.stringify({
     filesystems: [{ target, options: "rw,nosuid,nodev,relatime" }],
-  }), target);
-  validateActionPathGuardMount(JSON.stringify({
-    filesystems: [
-      { target, options: "ro,nosuid,nodev,relatime" },
-      { target, options: "rw,nosuid,nodev,relatime" },
-    ],
   }), target);
   for (const evidence of [
     { filesystems: [{ target, options: "ro,nosuid,nodev" }] },
@@ -617,7 +605,7 @@ test("requires registered Action path guards to remain exact writable mountpoint
     {
       filesystems: [
         { target, options: "rw,nosuid,nodev" },
-        { target: "/different", options: "rw,nosuid,nodev" },
+        { target, options: "rw,nosuid,nodev" },
       ],
     },
     { filesystems: [] },

--- a/action/test.cts
+++ b/action/test.cts
@@ -8,6 +8,7 @@ const path = require("node:path");
 const test = require("node:test");
 const {
   ACTION_RUNTIME_FILES,
+  actionMountRecordFromMountInfo,
   actionPathGuardIdentities,
   actionRuntimeDigest,
   actionRuntimeFileDigests,
@@ -574,6 +575,28 @@ test("parses only one bounded active mount identity", () => {
     "x".repeat(4097),
   ]) {
     assert.throws(() => mountIdFromFdInfo(fdInfo), /active mount identity/);
+  }
+});
+
+test("parses only the bounded active mount record", () => {
+  const target = "/opt/actions/fence action";
+  const mountInfo = "42 7 0:1 / /opt/actions/fence\\040action ro,nosuid,nodev shared:1 - ext4 /dev/root rw";
+  assert.deepEqual(
+    actionMountRecordFromMountInfo(mountInfo, target, "42"),
+    { target, options: "ro,nosuid,nodev", id: "42" },
+  );
+  for (const invalid of [
+    [mountInfo, target, "41"],
+    [mountInfo, "/different", "42"],
+    [mountInfo.replace("\\040", "\\777"), target, "42"],
+    [mountInfo.replace(" - ", " "), target, "42"],
+    [`${mountInfo}\n${mountInfo}`, target, "42"],
+    ["x".repeat(16 * 1024 + 1), target, "42"],
+  ]) {
+    assert.throws(
+      () => actionMountRecordFromMountInfo(invalid[0], invalid[1], invalid[2]),
+      /active mount record/,
+    );
   }
 });
 

--- a/action/test.cts
+++ b/action/test.cts
@@ -18,6 +18,7 @@ const {
   launcherIntegrityDocument,
   materializationRequestRejections,
   materializationWarningLines,
+  mountIdFromFdInfo,
   registeredActionPathGuardPaths,
   runtimePaths,
   summaryLines,
@@ -563,110 +564,96 @@ test("guards every renameable ancestor of the registered Action path", () => {
   }
 });
 
-test("requires the effective registered Action runtime mount to be read-only, nodev, and nosuid", () => {
-  const target = "/opt/actions/fence/action";
-  validateReadOnlyActionMount(JSON.stringify({
-    filesystems: [{ target, options: "ro,nosuid,nodev,relatime", id: 10, parent: 1 }],
-  }), target);
-  const stacked = Array.from({ length: 24 }, (_, index) => ({
-    target,
-    options: index === 23 ? "ro,nosuid,nodev,relatime" : "rw,relatime",
-    id: String(100 + index),
-    parent: String(index === 0 ? 1 : 99 + index),
-  }));
-  validateReadOnlyActionMount(JSON.stringify({ filesystems: stacked }), target);
+test("parses only one bounded active mount identity", () => {
+  assert.equal(mountIdFromFdInfo("pos:\t0\nflags:\t0100000\nmnt_id:\t42\n"), "42");
+  for (const fdInfo of [
+    "",
+    "mnt_id:\t0\n",
+    "mnt_id:\t01\n",
+    "mnt_id:\t1\nmnt_id:\t2\n",
+    "x".repeat(4097),
+  ]) {
+    assert.throws(() => mountIdFromFdInfo(fdInfo), /active mount identity/);
+  }
+});
 
-  for (const options of ["rw,nosuid,nodev", "ro,rw,nosuid,nodev", "ro,nodev", "ro,nosuid"]) {
+test("requires the active registered Action runtime mount to be read-only, nodev, and nosuid", () => {
+  const target = "/opt/actions/fence/action";
+  const mountId = "10";
+  validateReadOnlyActionMount(JSON.stringify({
+    filesystems: [{ target, options: "ro,nosuid,nodev,relatime", id: 10 }],
+  }), target, mountId);
+
+  for (const options of ["rw,nosuid,nodev", "ro,nodev", "ro,nosuid"]) {
     assert.throws(
       () => validateReadOnlyActionMount(JSON.stringify({
-        filesystems: [{ target, options, id: 10, parent: 1 }],
-      }), target),
+        filesystems: [{ target, options, id: 10 }],
+      }), target, mountId),
       /missing/,
     );
   }
-  assert.throws(
-    () => validateReadOnlyActionMount(JSON.stringify({
-      filesystems: [{
-        target: "/different",
-        options: "ro,nosuid,nodev",
-        id: 10,
-        parent: 1,
-      }],
-    }), target),
-    /does not match/,
-  );
+  for (const evidence of [
+    { filesystems: [{ target: "/different", options: "ro,nosuid,nodev", id: 10 }] },
+    { filesystems: [{ target, options: "ro,nosuid,nodev", id: 11 }] },
+  ]) {
+    assert.throws(
+      () => validateReadOnlyActionMount(JSON.stringify(evidence), target, mountId),
+      /does not match/,
+    );
+  }
   for (const filesystems of [
     [
-      { target, options: "ro,nosuid,nodev", id: 10, parent: 1 },
-      { target, options: "ro,nosuid,nodev", id: 11, parent: 1 },
+      { target, options: "ro,nosuid,nodev", id: 10 },
+      { target, options: "ro,nosuid,nodev", id: 11 },
     ],
-    [
-      { target, options: "ro,nosuid,nodev", id: 10, parent: 1 },
-      { target, options: "ro,nosuid,nodev", id: 10, parent: 10 },
-    ],
-    [{ target, options: "ro,nosuid,nodev", id: 10 }],
+    [{ target, options: "ro,nosuid,nodev", id: 10, parent: 1 }],
+    [{ target, options: "ro,nosuid,nodev" }],
     [],
   ]) {
     assert.throws(
-      () => validateReadOnlyActionMount(JSON.stringify({ filesystems }), target),
+      () => validateReadOnlyActionMount(JSON.stringify({ filesystems }), target, mountId),
       /incomplete/,
     );
   }
   assert.throws(
     () => validateReadOnlyActionMount(JSON.stringify({
-      filesystems: [
-        { target, options: "ro,nosuid,nodev", id: 10, parent: 1 },
-        { target, options: "rw,nosuid,nodev", id: 11, parent: 10 },
-      ],
-    }), target),
-    /missing/,
+      filesystems: [{ target, options: "ro,nosuid,nodev", id: 10 }],
+    }), target, "01"),
+    /incomplete/,
   );
-  assert.throws(() => validateReadOnlyActionMount("not-json", target), /malformed/);
+  assert.throws(() => validateReadOnlyActionMount("not-json", target, mountId), /malformed/);
 });
 
-test("requires effective registered Action path guards to remain exact writable mountpoints", () => {
+test("requires active registered Action path guards to remain exact writable mountpoints", () => {
   const target = "/srv/runner/work/project";
+  const mountId = "10";
   validateActionPathGuardMount(JSON.stringify({
-    filesystems: [{ target, options: "rw,nosuid,nodev,relatime", id: 10, parent: 1 }],
-  }), target);
-  validateActionPathGuardMount(JSON.stringify({
-    filesystems: [
-      { target, options: "ro,nosuid,nodev", id: 10, parent: 1 },
-      { target, options: "rw,nosuid,nodev,relatime", id: 11, parent: 10 },
-    ],
-  }), target);
+    filesystems: [{ target, options: "rw,nosuid,nodev,relatime", id: mountId }],
+  }), target, mountId);
   for (const evidence of [
-    { filesystems: [{ target, options: "ro,nosuid,nodev", id: 10, parent: 1 }] },
-    { filesystems: [{ target, options: "rw,ro,nosuid,nodev", id: 10, parent: 1 }] },
-    {
-      filesystems: [{
-        target: "/different",
-        options: "rw,nosuid,nodev",
-        id: 10,
-        parent: 1,
-      }],
-    },
+    { filesystems: [{ target, options: "ro,nosuid,nodev", id: 10 }] },
+    { filesystems: [{ target, options: "rw,ro,nosuid,nodev", id: 10 }] },
+    { filesystems: [{ target: "/different", options: "rw,nosuid,nodev", id: 10 }] },
+    { filesystems: [{ target, options: "rw,nosuid,nodev", id: 11 }] },
     {
       filesystems: [
-        { target, options: "rw,nosuid,nodev", id: 10, parent: 1 },
-        { target, options: "rw,nosuid,nodev", id: 11, parent: 1 },
+        { target, options: "rw,nosuid,nodev", id: 10 },
+        { target, options: "rw,nosuid,nodev", id: 11 },
       ],
     },
-    {
-      filesystems: [
-        { target, options: "rw,nosuid,nodev", id: 10, parent: 1 },
-        { target, options: "ro,nosuid,nodev", id: 11, parent: 10 },
-      ],
-    },
-    { filesystems: [{ target, options: "rw,nosuid,nodev", id: 10 }] },
+    { filesystems: [{ target, options: "rw,nosuid,nodev", id: 10, parent: 1 }] },
+    { filesystems: [{ target, options: "rw,nosuid,nodev" }] },
     { filesystems: [] },
   ]) {
     assert.throws(
-      () => validateActionPathGuardMount(JSON.stringify(evidence), target),
+      () => validateActionPathGuardMount(JSON.stringify(evidence), target, mountId),
       /guard mount/,
     );
   }
-  assert.throws(() => validateActionPathGuardMount("not-json", target), /malformed/);
+  assert.throws(
+    () => validateActionPathGuardMount("not-json", target, mountId),
+    /malformed/,
+  );
 });
 
 test("validates stable runtime evidence", () => {

--- a/action/test.cts
+++ b/action/test.cts
@@ -566,30 +566,60 @@ test("guards every renameable ancestor of the registered Action path", () => {
 test("requires the effective registered Action runtime mount to be read-only, nodev, and nosuid", () => {
   const target = "/opt/actions/fence/action";
   validateReadOnlyActionMount(JSON.stringify({
-    filesystems: [{ target, options: "ro,nosuid,nodev,relatime" }],
+    filesystems: [{ target, options: "ro,nosuid,nodev,relatime", id: 10, parent: 1 }],
   }), target);
-  for (const options of ["rw,nosuid,nodev", "ro,nodev", "ro,nosuid"]) {
+  const stacked = Array.from({ length: 24 }, (_, index) => ({
+    target,
+    options: index === 23 ? "ro,nosuid,nodev,relatime" : "rw,relatime",
+    id: String(100 + index),
+    parent: String(index === 0 ? 1 : 99 + index),
+  }));
+  validateReadOnlyActionMount(JSON.stringify({ filesystems: stacked }), target);
+
+  for (const options of ["rw,nosuid,nodev", "ro,rw,nosuid,nodev", "ro,nodev", "ro,nosuid"]) {
     assert.throws(
       () => validateReadOnlyActionMount(JSON.stringify({
-        filesystems: [{ target, options }],
+        filesystems: [{ target, options, id: 10, parent: 1 }],
       }), target),
       /missing/,
     );
   }
   assert.throws(
     () => validateReadOnlyActionMount(JSON.stringify({
-      filesystems: [{ target: "/different", options: "ro,nosuid,nodev" }],
+      filesystems: [{
+        target: "/different",
+        options: "ro,nosuid,nodev",
+        id: 10,
+        parent: 1,
+      }],
     }), target),
     /does not match/,
   );
+  for (const filesystems of [
+    [
+      { target, options: "ro,nosuid,nodev", id: 10, parent: 1 },
+      { target, options: "ro,nosuid,nodev", id: 11, parent: 1 },
+    ],
+    [
+      { target, options: "ro,nosuid,nodev", id: 10, parent: 1 },
+      { target, options: "ro,nosuid,nodev", id: 10, parent: 10 },
+    ],
+    [{ target, options: "ro,nosuid,nodev", id: 10 }],
+    [],
+  ]) {
+    assert.throws(
+      () => validateReadOnlyActionMount(JSON.stringify({ filesystems }), target),
+      /incomplete/,
+    );
+  }
   assert.throws(
     () => validateReadOnlyActionMount(JSON.stringify({
       filesystems: [
-        { target, options: "ro,nosuid,nodev" },
-        { target, options: "ro,nosuid,nodev" },
+        { target, options: "ro,nosuid,nodev", id: 10, parent: 1 },
+        { target, options: "rw,nosuid,nodev", id: 11, parent: 10 },
       ],
     }), target),
-    /incomplete/,
+    /missing/,
   );
   assert.throws(() => validateReadOnlyActionMount("not-json", target), /malformed/);
 });
@@ -597,17 +627,38 @@ test("requires the effective registered Action runtime mount to be read-only, no
 test("requires effective registered Action path guards to remain exact writable mountpoints", () => {
   const target = "/srv/runner/work/project";
   validateActionPathGuardMount(JSON.stringify({
-    filesystems: [{ target, options: "rw,nosuid,nodev,relatime" }],
+    filesystems: [{ target, options: "rw,nosuid,nodev,relatime", id: 10, parent: 1 }],
+  }), target);
+  validateActionPathGuardMount(JSON.stringify({
+    filesystems: [
+      { target, options: "ro,nosuid,nodev", id: 10, parent: 1 },
+      { target, options: "rw,nosuid,nodev,relatime", id: 11, parent: 10 },
+    ],
   }), target);
   for (const evidence of [
-    { filesystems: [{ target, options: "ro,nosuid,nodev" }] },
-    { filesystems: [{ target: "/different", options: "rw,nosuid,nodev" }] },
+    { filesystems: [{ target, options: "ro,nosuid,nodev", id: 10, parent: 1 }] },
+    { filesystems: [{ target, options: "rw,ro,nosuid,nodev", id: 10, parent: 1 }] },
+    {
+      filesystems: [{
+        target: "/different",
+        options: "rw,nosuid,nodev",
+        id: 10,
+        parent: 1,
+      }],
+    },
     {
       filesystems: [
-        { target, options: "rw,nosuid,nodev" },
-        { target, options: "rw,nosuid,nodev" },
+        { target, options: "rw,nosuid,nodev", id: 10, parent: 1 },
+        { target, options: "rw,nosuid,nodev", id: 11, parent: 1 },
       ],
     },
+    {
+      filesystems: [
+        { target, options: "rw,nosuid,nodev", id: 10, parent: 1 },
+        { target, options: "ro,nosuid,nodev", id: 11, parent: 10 },
+      ],
+    },
+    { filesystems: [{ target, options: "rw,nosuid,nodev", id: 10 }] },
     { filesystems: [] },
   ]) {
     assert.throws(

--- a/script/validate-locks
+++ b/script/validate-locks
@@ -180,10 +180,11 @@ marker = "\n  acceptance:\n"
 require(workflow.count(marker) == 1, "Action acceptance aggregate must be unique")
 aggregate = workflow.split(marker, 1)[1]
 required_fragments = [
-    "needs: [action, zero-input, setup-failure, tamper, verify-action-finalization]",
+    "needs: [action, zero-input, nested-layout, setup-failure, tamper, verify-action-finalization]",
     "if: ${{ always() && !cancelled() }}",
     "ACTION_RESULT: ${{ needs.action.result }}",
     "ZERO_INPUT_RESULT: ${{ needs.zero-input.result }}",
+    "NESTED_LAYOUT_RESULT: ${{ needs.nested-layout.result }}",
     "SETUP_FAILURE_RESULT: ${{ needs.setup-failure.result }}",
     "TAMPER_RESULT: ${{ needs.tamper.result }}",
     "FINALIZATION_RESULT: ${{ needs.verify-action-finalization.result }}",


### PR DESCRIPTION
## TL;DR

Bind mount verification to the kernel mount ID for the open registered Action path so downloaded Actions with stacked mounts do not fail setup. Keep the checks fail-closed and add a nested registered-path acceptance job that reproduces a consumer-shaped layout.