### PR TITLE
Release v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "fence"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fence"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.96.0"
 


### PR DESCRIPTION
## TL;DR

Publishes Fence `v0.4.0` with the root-only Azure WireServer platform handling, profile v4, and policy-hash schema 7 from #88.

The immutable release artifacts will be used by a separate attested Action-bundle refresh.
