### PR TITLE
Release v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "fence"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "clap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fence"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.96.0"
 


### PR DESCRIPTION
## TL;DR

Cuts v0.6.0 from the reviewed source state that closes the DNS lineage and hosted-runner containment gaps.

This change only advances the package version; the release workflow will build, publish, attest, and verify the immutable Linux x64 artifacts after merge.
