### PR TITLE
Release v0.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "fence"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "clap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fence"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 rust-version = "1.96.0"
 


### PR DESCRIPTION
## TL;DR

Cut v0.6.2 from the reviewed hosted-runner compatibility source state. This changes only Fence's package version in `Cargo.toml` and its own `Cargo.lock` entry.
