### PR TITLE
Streamline README and expand documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,34 +19,25 @@ Add Fence as the first step in a supported GitHub-hosted Linux job:
 - uses: GrantBirki/fence@<commit-sha>
 ```
 
-That one line starts Fence in `block` mode with an empty user `allowlist`.
-Fence currently supports GitHub-hosted `ubuntu-24.04` x64 host jobs.
+This starts Fence in `block` mode with an empty user `allowlist` on a GitHub-hosted `ubuntu-24.04` x64 host job. Replace `<commit-sha>` with the full `action_commit` value from a release's `action-release.json` asset; `main` is source-only and does not contain a runnable production bundle. Put Fence before checkout and any other steps you want it to constrain.
 
-Choose `<commit-sha>` from the `action_commit` field in the release's `action-release.json` asset. The `main` branch is source-only and intentionally does not contain a runnable production bundle. Each release-specific `vX.Y.Z` tag points to a signed generated distribution commit containing the reviewed wrapper plus the exact validated agent bundle, but consumers should still pin that distribution commit's full 40-character SHA instead of the tag.
-
-By default, Fence allows the GitHub domains needed for Actions job reporting.
-It also allows `github.com`, `api.github.com`,
-`release-assets.githubusercontent.com`, and the exact GitHub-hosted runner
-watchdog endpoint so Fence can run before checkout and common setup steps
-without suppressing runner health traffic. Fence does not make readiness depend
-on that optional endpoint resolving before startup. Those allowed GitHub
-domains are still places later workflow code can send data.
-
-Before readiness, required exact hostnames retry only transient or addressless
-DNS rounds, at most three attempts under one shared ten-second startup budget.
-Malformed or integrity-invalid DNS responses are not retried. A valid zero-TTL
-CNAME edge receives the same one-second minimum lifetime as a zero-TTL address.
-
-GitHub uploads job logs and summaries to a per-run Azure storage account.
-Fence authorizes at most four exact results-storage hostnames, and only when
-the DNS request comes from the pinned GitHub runner process. It does not allow
-the general `*.blob.core.windows.net` domain.
-
-The hosted VM also depends on Azure platform services. The v5 profile permits only UID `0` host traffic to WireServer at `168.63.129.16` on TCP ports `80` and `32526`, separately from the user `allowlist` and GitHub workflow destinations. Unprivileged workflow traffic and forwarded container traffic do not match those rules. The profile also permits host and forwarded traffic to Azure IMDS at `169.254.169.254` on TCP `80`; no other IMDS port is allowed. Fixed upstream DNS traffic is classified against the current socket policy before generic established/related acceptance. The released Action enforces the same contract through its attested bundled agent.
+**Read more:** [Getting started with Fence](docs/getting-started.md)
 
 ## Examples 🧪
 
-Run in audit mode first to see what would be blocked:
+Start with a complete job that activates Fence before checkout:
+
+```yaml
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: GrantBirki/fence@<fence-commit-sha>
+      - uses: actions/checkout@<checkout-commit-sha>
+      - run: script/test
+```
+
+Run in audit mode first to see what would need review before enabling blocking:
 
 ```yaml
 - uses: GrantBirki/fence@<commit-sha>
@@ -54,37 +45,29 @@ Run in audit mode first to see what would be blocked:
     mode: audit
 ```
 
-Allow a normal HTTPS hostname:
+Allow one or more HTTPS hostnames:
 
 ```yaml
 - uses: GrantBirki/fence@<commit-sha>
   with:
     allowlist: |
       api.example.com
+      artifacts.example.com
 ```
 
-Allow a hostname on a custom TCP port:
+Allow custom TCP, UDP, or CIDR destinations:
 
 ```yaml
 - uses: GrantBirki/fence@<commit-sha>
   with:
     allowlist: |
       registry.example.com:8443
-```
-
-Allow UDP or CIDR targets with the explicit line form:
-
-```yaml
-- uses: GrantBirki/fence@<commit-sha>
-  with:
-    allowlist: |
       udp://dns.example.com:53
       cidr 192.0.2.0/24 udp 123
       cidr 2001:db8::/64 tcp 443
 ```
 
-Keep Docker/container access available while still locking down the network and
-passwordless sudo, and lazily authorize one-label `docker.io` hostnames:
+Keep Docker/container access available while still applying network restrictions and disabling passwordless sudo:
 
 ```yaml
 - uses: GrantBirki/fence@<commit-sha>
@@ -94,12 +77,9 @@ passwordless sudo, and lazily authorize one-label `docker.io` hostnames:
       *.docker.io
 ```
 
-This pattern can authorize names such as `auth.docker.io` and
-`registry-1.docker.io`. It does not guarantee a complete image pull because
-layer, CDN, or storage traffic may use unrelated domains.
+The wildcard can authorize exact-depth names such as `auth.docker.io`, but image pulls may require additional registry, layer, CDN, or storage destinations.
 
-Disable the broad GitHub web/API/release-asset allowlist entries while keeping
-the core GitHub Actions reporting path alive:
+Remove the broad GitHub web, API, release-asset, and watchdog destinations while keeping the core Actions reporting path:
 
 ```yaml
 - uses: GrantBirki/fence@<commit-sha>
@@ -116,13 +96,11 @@ Use raw JSON only when you need exact agent-schema control:
       {"schema_version":1,"mode":"block","invocation_id":"my-job-1","allowlist":[]}
 ```
 
-Most users should not set `invocation_id`. The Action generates one as
-`fence-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}`. If you use raw JSON, set
-`invocation_id` to a lowercase unique slug for that job run.
+**Read more:** [Fence configuration examples](docs/examples.md)
 
 ## Allowlist Lines 📝
 
-The native `allowlist` input accepts one entry per line:
+The native `allowlist` input accepts one destination per line:
 
 ```text
 example.com
@@ -137,72 +115,24 @@ cidr 192.0.2.0/24 udp 123
 cidr 2001:db8::/64 tcp 443
 ```
 
-Blank lines and lines starting with `#` are ignored. Hostname shortcuts default
-to `tcp` port `443`. IPv6 or non-hostname entries should use the explicit
-`ip` or `cidr` form.
+Hostname shortcuts use TCP port `443`; use the explicit `ip` or `cidr` form for address ranges and IPv6. Blank lines and comments beginning with `#` are ignored. Wildcards match exactly one or two leading labels and share a bounded lifetime authorization budget.
 
-Fence resolves exact hostname entries before lockdown is ready and refreshes
-their approved addresses while the job runs. Each hostname keeps the protocol
-and port you configured as DNS answers change.
-
-The Action and agent accept exact-depth `*.example.com` and `*.*.example.com`
-hostname patterns. Each `*` represents exactly one DNS label, and all user
-patterns share an eight-name lifetime authorization budget. These names
-materialize lazily after matching DNS queries and do not delay readiness.
-Fence validates DNS structure rather than registrable-domain ownership, so use
-broad or shared suffixes only as explicit egress and DNS-data-channel choices.
-Derived DNS aliases are accepted only when every alias belongs to one acyclic
-response chain rooted at the hostname that was queried. An unrelated alias or
-address owner fails closed without creating later hostname authorization.
+**Read more:** [Allowlist syntax and DNS behavior](docs/allowlist.md)
 
 ## How It Works 🔧
 
-1. Your workflow starts with `uses: GrantBirki/fence@<commit-sha>`.
-2. The Action protects its post-job code and bundled agent with a root-owned,
-   read-only mount.
-3. The Action writes a small root-owned config under `/run/fence/`.
-4. The bundled Fence agent starts through `sudo` and `systemd`.
-5. Fence checks the supported GitHub-hosted Linux shape, including fixed
-   privileged executables, effective runner access to their paths and sudo
-   policy, and the reviewed local root-control inventory.
-6. In default `block` mode, Fence allows GitHub workflow traffic plus your
-   `allowlist`, blocks other outbound network access, turns off passwordless
-   sudo, and disables Docker/container access.
-7. Fence keeps running until the runner is destroyed, rechecks the local
-   root-control inventory with the other controls every five seconds, and
-   records local evidence. Network findings may include bounded, best-effort
-   local process attribution.
-8. The protected post-job hook prints a compact **Fence Summary** with control
-   results and observed network activity, then fails the job if Fence sees
-   critical drift.
+Fence validates that it is running through the supported Action path, turns your inputs into a local policy, and applies the controls for the selected mode. A resident agent keeps checking those controls throughout the job, and the protected post-job hook reports what happened and fails the job if it finds critical drift.
 
 ```mermaid
-flowchart TD
-    start["GitHub-hosted Linux job starts"] --> action["Fence Action runs first"]
-    action --> input["Read native Action inputs<br/>default: block mode + empty allowlist"]
-    input --> protect["Protect registered Action path<br/>stable ancestors + read-only runtime"]
-    protect --> config["Write root-owned config<br/>under /run/fence/"]
-    config --> launch["Launch bundled agent<br/>with sudo + systemd"]
-
-    launch --> support["Check supported runner shape"]
-    support --> plan["Build network plan<br/>GitHub workflow traffic + allowlist"]
-    plan --> network["Apply Linux nftables rules<br/>and local DNS handling"]
-    network --> gate["Release approved DNS answers<br/>after matching firewall access is verified"]
-
-    gate --> mode{"Selected mode"}
-    mode --> block["block<br/>turn off passwordless sudo<br/>turn off Docker"]
-    mode --> degraded["unsafe_preserve<br/>turn off passwordless sudo<br/>keep Docker"]
-    mode --> audit["audit<br/>observe only<br/>keep sudo and Docker"]
-
-    block --> ready["Write ready/report files"]
-    degraded --> ready
-    audit --> ready
-
-    ready --> resident["Fence keeps running<br/>checks controls every 5 seconds"]
-    resident --> post["Protected post hook<br/>verifies runtime + evidence"]
-    post --> summary["Render Fence Summary<br/>fail on critical drift"]
-    summary --> teardown["Runner teardown removes the VM"]
+flowchart LR
+    start["Fence runs first"] --> verify["Validate runner and trusted bundle"]
+    verify --> policy["Build GitHub traffic and user policy"]
+    policy --> controls["Apply mode-specific controls"]
+    controls --> monitor["Monitor controls during the job"]
+    monitor --> report["Report evidence and critical drift"]
 ```
+
+**Read more:** [Fence architecture and lifecycle](docs/how-it-works.md)
 
 ## Modes 🎛️
 
@@ -212,92 +142,27 @@ flowchart TD
 | `block` with `container_policy: unsafe_preserve` | Blocks network traffic and turns off passwordless sudo, but leaves Docker/container access available. | When a workflow needs Docker and you accept the weaker security claim. |
 | `audit` | Does not block traffic. Records what would need review before moving to `block`. | When tuning a workflow. |
 
+**Read more:** [Fence assurance modes](docs/v0.md#assurance-modes)
+
 ## Security Notes 🔒
 
-Fence reduces where later workflow steps can send data and removes common ways
-to undo the lockdown. It is not a full sandbox, and it does not make a runner
-perfectly hermetic.
+Fence reduces where later workflow steps can send data and removes common ways to undo the lockdown. It is not a full sandbox, does not make a runner perfectly hermetic, and currently supports only GitHub-hosted `ubuntu-24.04` x64 host jobs.
 
-The default GitHub allowlist is a usability tradeoff. It keeps normal GitHub
-Actions reporting, checkout, API, and release-asset flows working, but later
-workflow code can also send data to those allowed GitHub destinations. Set
-`disable_broad_github_domains: true` if you want to remove `github.com`,
-`api.github.com`, `release-assets.githubusercontent.com`, and the exact hosted
-runner watchdog endpoint from the default allowlist. GitHub's exact
-runner-authorized results-storage account also becomes a reachable destination
-for the rest of the job; Fence records that authorization locally and limits it
-to TCP port `443`.
+The built-in GitHub destinations are a compatibility tradeoff because later workflow code can also reach them. Pin Fence to the full immutable `action_commit` SHA from a release, use `disable_broad_github_domains: true` when the narrower GitHub path is sufficient, and treat `container_policy: unsafe_preserve` as a deliberately weaker mode.
 
-Fence supports only GitHub-hosted `ubuntu-24.04` x64 host jobs today. The `ubuntu-latest` canary is useful signal, but it does not expand the support claim. A separate daily fixed-label canary fails on fingerprint drift or a skipped bundle activation and verifies the zero-input standard lifecycle on the supported runner. Pin Fence to the full immutable `action_commit` SHA reported by the release, not `@main` or a version tag.
-
-## Release Provenance 🔏
-
-A reviewed pull request containing the code change and `Cargo.toml`/`Cargo.lock` version bump is the only human release authorization. After that pull request merges, the release workflow treats the signed merge commit as source commit `M`, builds and attests the Linux x64 artifact from `M`, and creates a GitHub-signed child distribution commit `D` whose sole parent is `M`. The only files added by `D` are `action/bin/fence` and the schema-`4` `action/bundle-manifest.json`.
-
-The release workflow runs the complete Action acceptance matrix and fixed-runner canary against `D` before publishing an immutable `vX.Y.Z` release whose tag targets `D`. The release's `action-release.json` asset maps the version, source commit `M`, distribution commit `D`, artifact digest, manifest schema, and release-workflow identity. Release assets remain attested to the reviewed source commit `M`; the generated commit records that source and signer digest without attempting to contain its own SHA.
-
-Fence never downloads the agent or policy at Action runtime. The committed bundle bytes are checksum-validated, copied into the protected root-owned launcher directory with executable mode, and launched only from that protected copy. Releases through `v0.6.3` retain their historical tag semantics; the generated distribution-commit model applies beginning with the first later release.
-
-Fence rejects activation when fixed privileged commands, their reviewed path ancestors, sudo-policy source identities, metadata, and exact accepted content digests, or the bounded root TCP/Unix and container inventory do not match the reviewed runner shape. Standard block permits only the expected removal of measured container-control state before readiness, then treats any later inventory change as critical drift. These checks rely on Fence running first on the trusted hosted image; they do not authenticate a command that was already modified by a compromised root or platform component before Fence started.
-
-Fence does not upload telemetry. When it records a blocked or would-block
-connection, it may add the local process ID, executable basename, actor class,
-and up to four parent executable basenames. Process races or shared sockets can
-produce `not_found` or `ambiguous` attribution. Fence never records command
-arguments, full executable paths, environments, working directories, or packet
-payloads.
-
-## Troubleshooting 🧯
-
-Fence prints a short progress log during setup and a compact **Fence Summary**
-with control and network-activity tables at the end of the job. If setup fails
-and you need more detail, enable the
-standard GitHub Actions debug flag by setting the repository secret
-`ACTIONS_STEP_DEBUG` to `true`. Debug logs include bounded service status and
-Fence-specific diagnostics, but they avoid raw config bodies, environment
-values, packet payloads, and unrelated system logs.
-
-## Local Development ✈️
-
-Fence follows the airplane-test model described in
-[Hermetic Builds](https://software.birki.io/posts/hermetic-builds/). Prepare
-toolchains deliberately, then run normal project commands from pinned vendored
-inputs.
-
-```console
-script/prepare-rust
-script/bootstrap
-script/test
-script/lint
-script/build
-```
-
-`script/assemble-action-bundle` is the offline-only path for constructing a production-shaped Action tree from an explicit artifact, version, source SHA, and output root. It verifies those inputs and writes only below the requested output root; it does not fetch a release, agent, attestation, or policy. Pull-request validation uses this path to test an ephemeral candidate without adding generated bundle files to `main`.
-
-Preparation downloads only the manifest, host components, and requested target
-libraries named in the checked-in Rust distribution lock. Each download is
-checksum-verified before rustup installs it from a temporary loopback-only
-mirror. The fully qualified version-and-host toolchain is replaced only after
-the complete selected artifact set verifies; caller-provided distribution and
-update sources are not used, and rustup self-update is disabled.
-
-## CLI 🧰
-
-Most users should use the Action. The bundled Rust agent also exposes a narrow
-JSON-only CLI:
-
-```console
-fence --version
-fence check-support
-fence render-plan --config policy.json
-fence run --config /run/fence/example/config.json
-```
-
-Direct `fence run` is rejected unless it is launched through the trusted
-Action/systemd path.
+**Read more:** [Security boundaries and operational guidance](docs/security.md)
 
 ## Further Reading 📚
 
+- [Getting started](docs/getting-started.md)
+- [Configuration examples](docs/examples.md)
+- [Allowlist syntax](docs/allowlist.md)
+- [Architecture and lifecycle](docs/how-it-works.md)
+- [Security boundaries](docs/security.md)
+- [Release provenance](docs/release-provenance.md)
+- [Troubleshooting](docs/troubleshooting.md)
+- [Local development](docs/development.md)
+- [CLI reference](docs/cli.md)
 - [Fence v0 security contract](docs/v0.md)
 - [Threat model](docs/threat-model.md)
 - [Security policy](SECURITY.md)

--- a/docs/allowlist.md
+++ b/docs/allowlist.md
@@ -1,0 +1,48 @@
+# Allowlist Syntax And DNS Behavior
+
+The native Action `allowlist` input accepts one entry per line. Blank lines and lines beginning with `#` are ignored.
+
+## Accepted Forms
+
+```text
+example.com
+example.com:8443
+tcp://example.com:443
+udp://dns.example.com:53
+hostname example.com tcp 443
+*.example.com
+*.*.example.com
+ip 192.0.2.10 tcp 443
+cidr 192.0.2.0/24 udp 123
+cidr 2001:db8::/64 tcp 443
+```
+
+- `example.com` means TCP port `443`.
+- `example.com:8443`, `tcp://...`, and `udp://...` select a specific transport and port.
+- `hostname ...`, `ip ...`, and `cidr ...` are the explicit forms.
+- Literal IPv6 addresses and address ranges should use `ip` or `cidr` so the port remains unambiguous.
+
+## Exact Hostnames
+
+Fence resolves every required exact hostname before readiness, applies and verifies rules for all approved addresses, and refreshes those addresses while the job runs. Each refreshed address retains the protocol and port from its allowlist entry.
+
+Only `A` and `AAAA` questions are forwarded in block mode. Fence rebuilds outbound questions in canonical lowercase form and releases an approved address-bearing answer only after the corresponding firewall access has been applied and structurally verified.
+
+## Wildcard Hostnames
+
+The supported wildcard forms are `*.example.com` and `*.*.example.com`. Each `*` matches exactly one DNS label:
+
+- `*.example.com` matches `api.example.com` but not `example.com` or `one.two.example.com`.
+- `*.*.example.com` matches `one.two.example.com` but not `api.example.com` or `three.one.two.example.com`.
+
+All user wildcard entries share one eight-name lifetime authorization budget. Wildcard names materialize only after matching runtime DNS queries, do not prehydrate, and do not delay readiness.
+
+Fence validates DNS structure, not registrable-domain ownership. A wildcard over a broad or shared suffix therefore creates both an egress choice and a DNS data channel; use the narrowest suffix that fits the workflow.
+
+## CNAME And Address Handling
+
+Derived CNAME authorization must form one acyclic response-local chain rooted at the echoed question. Every alias inherits the queried root's transport policy and stays within bounded TTL, depth, and capacity limits. An unrelated alias, address-family mismatch, malformed response, incomplete address coverage, or attribution failure fails closed without creating later authorization.
+
+Duplicate terminal addresses use the minimum observed TTL. Valid zero-TTL addresses and zero-TTL CNAME edges receive a one-second materialization lifetime before the fixed refresh overlap.
+
+For the complete normative policy, see [Effective Policy](v0.md#effective-policy) in the Fence v0 specification.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,40 @@
+# CLI Reference
+
+Most users should use the GitHub Action. The native Rust agent exposes a narrow command-line interface for version inspection, support checks, deterministic plan rendering, and the trusted production lifecycle.
+
+```console
+fence --version
+fence check-support
+fence render-plan --config policy.json
+fence run --config /run/fence/example/config.json
+```
+
+## `fence --version`
+
+Prints the source-agent version. `Cargo.toml` is the version authority for source builds; a published bundle's schema-`4` manifest is the bundled-agent version and provenance authority.
+
+## `fence check-support`
+
+Checks whether the current host matches the accepted hosted-runner fingerprint reference. This is an inspection result and does not apply controls or claim active protection.
+
+## `fence render-plan`
+
+Parses strict JSON configuration and emits a deterministic native nftables preview without applying the production lifecycle:
+
+```console
+fence render-plan --config policy.json
+```
+
+The configuration must satisfy the same schema and bounded policy validation used by the agent.
+
+## `fence run`
+
+Production `run` is intentionally not a general-purpose root CLI. It accepts only `/run/fence/<invocation-id>/config.json`, requires pinned root-owned runtime directories and a root-owned `0600` regular configuration file, and validates that the process is the root `MainPID` of the matching `fence-<invocation-id>.service` transient unit.
+
+An ordinary direct invocation fails with `trusted_launcher_required` before reading configuration:
+
+```console
+fence run --config /run/fence/example/config.json
+```
+
+Use the checked-in GitHub Action to create the protected launcher path and production lifecycle. See [Architecture and Lifecycle](how-it-works.md) for the full sequence and the [configuration interface](v0.md#configuration-interface) for the normative CLI contract.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,39 @@
+# Local Development
+
+Fence follows the airplane-test model described in [Hermetic Builds](https://software.birki.io/posts/hermetic-builds/): prepare toolchains deliberately, then build, test, lint, and package from pinned vendored inputs without network access.
+
+## Prepare And Validate
+
+```console
+script/prepare-rust
+script/bootstrap
+script/test
+script/lint
+script/build
+```
+
+`script/prepare-rust` is the explicit online Rust preparation path. It validates the checked-in distribution lock, downloads only the selected manifest, host components, and requested target libraries, verifies every SHA-256, and lets rustup install only from a temporary loopback mirror. Caller-provided Rust distribution and update sources are ignored, and rustup self-update is disabled.
+
+The routine project scripts are offline:
+
+- `script/bootstrap` validates the pinned toolchain and vendored crates, then runs a frozen Cargo check.
+- `script/test` runs the offline regression suite and frozen Rust tests.
+- `script/lint` runs the repository's pinned formatting, lint, and policy checks.
+- `script/build` creates the supported build outputs from vendored inputs.
+- `script/server` runs the local project entrypoint without adding network behavior.
+
+Use `script/update`, `script/vendor-rust`, and the focused `script/vendor-*-tools` entrypoints only when intentionally refreshing dependencies or retained tools. Those are explicit online maintenance boundaries, not part of the normal offline workflow.
+
+## Action Bundle Assembly
+
+`script/assemble-action-bundle` is the offline-only path for constructing a production-shaped Action tree from an explicit artifact, version, source SHA, and output root. It verifies those inputs and writes only below the requested output root; it does not fetch a release, agent, attestation, or policy.
+
+Pull-request and ordinary `main` validation use this path to test an ephemeral candidate. Generated `action/bin/fence` and `action/bundle-manifest.json` files do not land on `main`; release automation adds them only to the signed distribution commit.
+
+## Local Artifacts
+
+Outside CI, `script/env` defaults `RUNNER_TEMP` and `TMPDIR` to ignored paths below `target/tmp` when the caller has not supplied them. Keep disposable Rust, Cargo, Zig, archive-extraction, and prepared-tool output inside the repository's ignored `target/` tree when practical.
+
+Do not run the destructive hosted-runner evidence scripts on a developer machine or reusable runner. The script contracts in [AGENTS.md](../AGENTS.md) identify the entrypoints restricted to disposable GitHub-hosted jobs.
+
+For exact build, test, coverage, release, and hermeticity requirements, see the [Fence v0 specification](v0.md#hermetic-repository-contract).

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,123 @@
+# Configuration Examples
+
+All examples use `<commit-sha>` as a placeholder. Replace it with the full `action_commit` value from the release's `action-release.json` asset.
+
+## Minimal Block Mode
+
+The zero-input configuration enables standard `block` mode with no user-defined destinations:
+
+```yaml
+- uses: GrantBirki/fence@<commit-sha>
+```
+
+## Audit A Workflow
+
+Use `audit` to observe activity without blocking traffic or disabling passwordless sudo and container access:
+
+```yaml
+- uses: GrantBirki/fence@<commit-sha>
+  with:
+    mode: audit
+```
+
+Review the final **Fence Summary**, add only the destinations the job needs, and then move to `block` mode.
+
+## Allow HTTPS Destinations
+
+Bare hostnames use TCP port `443`:
+
+```yaml
+- uses: GrantBirki/fence@<commit-sha>
+  with:
+    allowlist: |
+      api.example.com
+      artifacts.example.com
+```
+
+Exact hostname entries resolve before readiness and refresh from bounded DNS lifetimes while Fence remains active.
+
+## Use Custom Ports And Protocols
+
+The short URI forms and explicit line forms can be mixed:
+
+```yaml
+- uses: GrantBirki/fence@<commit-sha>
+  with:
+    allowlist: |
+      registry.example.com:8443
+      tcp://cache.example.com:9443
+      udp://dns.example.com:53
+      ip 192.0.2.10 tcp 443
+      cidr 192.0.2.0/24 udp 123
+      cidr 2001:db8::/64 tcp 443
+```
+
+Use the explicit `ip` and `cidr` forms for literal addresses, especially IPv6.
+
+## Preserve Container Access
+
+Standard block mode disables Docker and containerd control paths. If the workflow needs containers, explicitly select the degraded policy:
+
+```yaml
+- uses: GrantBirki/fence@<commit-sha>
+  with:
+    container_policy: unsafe_preserve
+    allowlist: |
+      auth.docker.io
+      registry-1.docker.io
+```
+
+This still applies the network policy and disables passwordless sudo, but retained container access invalidates the standard containment claim.
+
+## Use A Bounded Hostname Wildcard
+
+One- and two-label leading wildcards are exact-depth patterns:
+
+```yaml
+- uses: GrantBirki/fence@<commit-sha>
+  with:
+    allowlist: |
+      *.docker.io
+      *.*.example.com
+```
+
+`*.docker.io` can match `auth.docker.io`, but it does not match `docker.io` or `one.two.docker.io`. All user wildcard patterns share an eight-name lifetime authorization budget and materialize only after matching runtime DNS queries.
+
+## Narrow The Built-In GitHub Policy
+
+Remove the broad GitHub web, API, release-asset, watchdog, and platform-origin GitHub application compatibility destinations while keeping the core Actions reporting and finalization path:
+
+```yaml
+- uses: GrantBirki/fence@<commit-sha>
+  with:
+    disable_broad_github_domains: true
+```
+
+An explicit user wildcard is not removed by this input.
+
+## Supply A Platform Profile Explicitly
+
+The only accepted profile is the supported v5 profile, which is also selected when the input is omitted:
+
+```yaml
+- uses: GrantBirki/fence@<commit-sha>
+  with:
+    platform_profile: github_hosted_workflow_bootstrap_v5
+```
+
+Other profile values are rejected before mutation.
+
+## Use Raw JSON
+
+The advanced `config` input exposes the strict agent schema:
+
+```yaml
+- uses: GrantBirki/fence@<commit-sha>
+  with:
+    config: >-
+      {"schema_version":1,"mode":"block","invocation_id":"my-job-1","allowlist":[]}
+```
+
+Do not combine `config` with native configuration inputs. Most users should let the Action generate `invocation_id`; raw JSON callers must provide a lowercase unique slug for the job run.
+
+See [allowlist syntax](allowlist.md) for every accepted line form and the [Fence v0 specification](v0.md#configuration-interface) for the strict configuration contract.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,43 @@
+# Getting Started
+
+Fence is a GitHub Action for supported GitHub-hosted `ubuntu-24.04` x64 host jobs. It must run before checkout and any other steps you want it to constrain.
+
+## Add Fence To A Job
+
+Use the full 40-character `action_commit` value from the release's `action-release.json` asset:
+
+```yaml
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: GrantBirki/fence@<fence-commit-sha>
+      - uses: actions/checkout@<checkout-commit-sha>
+      - run: script/test
+```
+
+The root `main` branch is source-only and intentionally omits the generated agent bundle. A release-specific `vX.Y.Z` tag identifies a signed distribution commit, but consumers should pin the immutable distribution commit from `action-release.json` rather than the tag.
+
+## Default Behavior
+
+With no inputs, the Action starts Fence in `block` mode with an empty user `allowlist`. Fence permits the bounded platform traffic required for the GitHub-hosted runner, blocks other outbound traffic, disables passwordless sudo, and disables Docker and containerd control paths.
+
+Fence allows the core GitHub Actions status and finalization endpoints. The default compatibility profile also includes `github.com`, `api.github.com`, `release-assets.githubusercontent.com`, the exact optional hosted-runner watchdog endpoint, and a bounded class of GitHub application hostnames. Set `disable_broad_github_domains: true` to remove those broader platform-origin destinations while retaining the core Actions path.
+
+GitHub uploads job logs and summaries to per-run Azure storage accounts. Fence always permits the exact reviewed compatibility account and can authorize at most four additional exact results-storage hostnames when the DNS request is attributable to the pinned GitHub runner process; it never permits the general `*.blob.core.windows.net` suffix.
+
+The supported hosted VM also depends on Azure platform services. The selected profile permits root-only host access to WireServer at `168.63.129.16` on TCP ports `80` and `32526`, plus host and forwarded access to Azure IMDS at `169.254.169.254` on TCP port `80`. These are separate platform rules, not user allowlist entries.
+
+## Startup And Readiness
+
+Before reporting readiness, Fence checks the supported runner fingerprint, prepares the selected network policy, applies and verifies the required controls, and resolves required exact hostnames. Transient or addressless DNS results receive at most three attempts within one shared ten-second startup deadline; malformed or integrity-invalid responses fail immediately.
+
+After readiness, Fence remains resident and verifies the controls every five seconds. It never restores access at the end of the job; the disposable GitHub-hosted VM teardown removes the state.
+
+## Choose A Mode
+
+- Use the default `block` mode for the strongest supported containment claim.
+- Use `audit` to observe the policy before enabling blocking.
+- Use `container_policy: unsafe_preserve` only when the workflow requires Docker or containerd access and you accept the weaker containment boundary.
+
+See [configuration examples](examples.md), [allowlist syntax](allowlist.md), and the normative [Fence v0 specification](v0.md) for the complete contract.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,0 +1,55 @@
+# Architecture And Lifecycle
+
+Fence combines an immutable GitHub Action wrapper, a native Rust agent, local DNS mediation, Linux nftables policy, privilege and container controls, resident verification, and a protected post-job summary.
+
+## Lifecycle
+
+1. The workflow invokes the pinned Fence Action before checkout or other untrusted steps.
+2. The wrapper validates its bundled manifest and protects the registered Action path with a root-owned read-only mount.
+3. The wrapper validates native inputs, writes a root-owned configuration below `/run/fence/<invocation-id>/`, and launches the bundled agent as the main process of a matching transient systemd service.
+4. The agent checks the supported GitHub-hosted runner fingerprint, including trusted executables and ancestors, sudo-policy sources, runner identity, and the bounded local root-control inventory.
+5. The agent builds the selected profile and user policy, starts local DNS mediation, applies mode-specific nftables and privilege controls, and verifies the resulting state before writing readiness.
+6. In block mode, approved DNS answers are released only after all corresponding firewall rules have been applied and structurally verified.
+7. The agent remains resident and rechecks the firewall, privilege/container state, local-control inventory, worker health, and local evidence every five seconds. Critical resident health never returns to healthy.
+8. The protected post-job hook validates the active service and evidence, prints a compact **Fence Summary**, and fails the job when critical drift is present. Fence does not restore access; disposable runner teardown removes the VM.
+
+## Detailed Flow
+
+```mermaid
+flowchart TD
+    start["GitHub-hosted Linux job starts"] --> action["Fence Action runs first"]
+    action --> input["Read native Action inputs<br/>default: block mode + empty allowlist"]
+    input --> protect["Protect registered Action path<br/>stable ancestors + read-only runtime"]
+    protect --> config["Write root-owned config<br/>under /run/fence/"]
+    config --> launch["Launch bundled agent<br/>with sudo + systemd"]
+
+    launch --> support["Check supported runner shape"]
+    support --> plan["Build network plan<br/>GitHub workflow traffic + allowlist"]
+    plan --> network["Apply Linux nftables rules<br/>and local DNS handling"]
+    network --> gate["Release approved DNS answers<br/>after matching firewall access is verified"]
+
+    gate --> mode{"Selected mode"}
+    mode --> block["block<br/>turn off passwordless sudo<br/>turn off Docker"]
+    mode --> degraded["unsafe_preserve<br/>turn off passwordless sudo<br/>keep Docker"]
+    mode --> audit["audit<br/>observe only<br/>keep sudo and Docker"]
+
+    block --> ready["Write ready/report files"]
+    degraded --> ready
+    audit --> ready
+
+    ready --> resident["Fence keeps running<br/>checks controls every 5 seconds"]
+    resident --> post["Protected post hook<br/>verifies runtime + evidence"]
+    post --> summary["Render Fence Summary<br/>fail on critical drift"]
+    summary --> teardown["Runner teardown removes the VM"]
+```
+
+## Major Components
+
+- **Action wrapper:** Converts the common native inputs into strict agent configuration, validates the bundled artifact, creates the protected launcher path, and registers the post-job hook.
+- **Runtime intake:** Accepts only the expected root-owned, no-follow configuration path and matching transient service identity.
+- **Platform profile:** Describes the supported runner fingerprint and the bounded GitHub Actions, Azure platform, DNS, sudo, container, and local-control expectations.
+- **DNS mediator and firewall owner:** Attribute DNS requests, validate policy and response lineage, serialize firewall updates, and publish answers only after access is verified.
+- **Resident verifier:** Rechecks controls and worker health every five seconds and records bounded local evidence.
+- **Post-job hook:** Validates the live service and evidence, renders the final summary, and converts critical findings into job failure.
+
+The [Fence v0 specification](v0.md) is the normative behavior contract. The [threat model](threat-model.md) explains the trust boundaries and attacker assumptions.

--- a/docs/release-provenance.md
+++ b/docs/release-provenance.md
@@ -1,0 +1,43 @@
+# Release Provenance
+
+A reviewed pull request containing the behavior change and matching `Cargo.toml` and root `Cargo.lock` version bump is the sole human release authorization. Release workflows do not expose a manual dispatch path.
+
+## Source And Distribution Commits
+
+After the pull request merges, the release workflow treats the signed `main` merge commit as source commit `M`. It builds and attests one Linux x64 artifact from `M`, then creates a GitHub-signed one-parent distribution commit `D` whose sole parent is `M`.
+
+The only files added by `D` are:
+
+- `action/bin/fence`
+- `action/bundle-manifest.json`
+
+The schema-`4` manifest records the repository, release tag and channel, release URL, source commit and ref, artifact name and SHA-256, bundle path, signer workflow, and signer digest. Both `source_commit` and `signer_digest` identify `M`; the manifest does not attempt to embed the self-referential distribution commit SHA.
+
+## Acceptance And Publication
+
+The release workflow runs the complete Action acceptance matrix and fixed-runner zero-input canary against exact distribution commit `D` before publication. The immutable `vX.Y.Z` release tag targets `D`, and the release's `action-release.json` asset maps:
+
+- version
+- source commit `M`
+- distribution commit `D`
+- artifact name and digest
+- manifest schema version
+- signer workflow and signer digest
+
+Release assets remain attested to reviewed source commit `M`, while the generated distribution commit records the bundled bytes and their source provenance.
+
+## Consumer Pinning
+
+Consumers must pin the full 40-character `action_commit` value from `action-release.json`:
+
+```yaml
+- uses: GrantBirki/fence@<action-commit>
+```
+
+Do not consume Fence from `main`; it is intentionally source-only and omits the generated bundle. A version tag identifies the release, but the immutable distribution commit is the supported workflow reference. Releases through `v0.6.3` retain their historical tag semantics; the one-parent distribution-commit model begins with the first later release.
+
+## Runtime Bundle Integrity
+
+Fence never downloads an agent, policy, or attestation at Action runtime. The wrapper validates the checked-in bundle manifest and checksum, copies the agent into a protected root-owned launcher directory with executable mode, and launches only that protected copy.
+
+See the [CI and release contract](v0.md#ci-and-release-contract) for the normative pipeline requirements and [Required Repository Settings](repository-settings.md) for the GitHub configuration that supports them.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,43 @@
+# Security Boundaries And Operational Guidance
+
+Fence reduces where later workflow steps can send data and removes common ways for those steps to undo the restriction. It is a narrow security control for one supported runner class, not a general sandbox or a claim that the job is fully hermetic.
+
+## Supported Boundary
+
+The protected v0 target is a GitHub-hosted `ubuntu-24.04` x64 host job running the native Linux GNU Action bundle. The `ubuntu-latest` canary provides drift signal but does not expand that support claim. Container jobs, other runner images, self-hosted runners, other architectures, and direct CLI launches do not establish the protected production lifecycle.
+
+Fence should run before checkout and all other steps that need restriction. It checks a reviewed hosted-runner fingerprint before mutation, but it does not authenticate a privileged command or platform component that was already compromised before Fence started.
+
+## Mode Boundaries
+
+- Standard `block` applies the bounded network policy, disables measured passwordless sudo, disables accepted Docker/containerd control paths, and verifies the post-mutation baseline before readiness.
+- `block` with `container_policy: unsafe_preserve` keeps container access available. It still applies the network policy and disables passwordless sudo, but the retained container control plane invalidates the ordinary containment claim.
+- `audit` observes policy activity without blocking traffic and preserves passwordless sudo and container access. Its readiness is explicitly observation-only.
+
+Fence never silently downgrades from standard block mode to a weaker mode.
+
+## Allowed Destinations Remain Reachable
+
+The built-in GitHub policy is a compatibility tradeoff. Core Actions status and finalization endpoints must remain reachable, and the default profile also permits broader GitHub web, API, release-asset, watchdog, and bounded GitHub application destinations. Later workflow code can send data to any destination that remains allowed.
+
+Set `disable_broad_github_domains: true` to remove `github.com`, `api.github.com`, `release-assets.githubusercontent.com`, the exact optional hosted-runner watchdog, and new platform-origin broad GitHub application authorizations. This does not remove the core reporting path, exact results-storage compatibility, or an explicit user wildcard.
+
+GitHub's authorized results-storage accounts are also reachable over TCP port `443` for the rest of the job after authorization. Fence limits dynamic authorization to DNS requests from the pinned runner process and records the bounded authorization locally; it does not permit the general Azure Blob Storage suffix.
+
+## Integrity And Drift
+
+The Action validates its checked-in manifest, copies the bundled agent into a protected root-owned launcher directory, and starts only that protected copy. The agent validates trusted executable identities, reviewed path ancestors, sudo-policy sources, runner identity, and the bounded root TCP, Unix, and container inventory before protection is claimed.
+
+After readiness, Fence rechecks its firewall, lockdown or observation state, local-control inventory, required worker health, and evidence every five seconds. A critical resident failure is permanent and causes the protected post-job hook to fail the job. Fence intentionally does not restore network, sudo, or container access before the disposable VM is torn down.
+
+## Local Evidence And Privacy
+
+Fence does not upload telemetry. Local reports contain bounded control results, network decisions, and findings. Best-effort process attribution may include attribution status, actor class, PID, executable basename, and up to four parent executable basenames; it excludes command arguments, full executable paths, environments, working directories, and packet payloads.
+
+Process races and shared sockets can produce `not_found` or `ambiguous` attribution. Attribution enriches local evidence but does not decide whether a destination is allowed.
+
+## Pinning And Provenance
+
+Consumers should pin the full immutable `action_commit` SHA from the release's `action-release.json` asset. Do not consume Fence from `main` or rely on a version tag as the workflow reference. See [Release Provenance](release-provenance.md) for the source, distribution commit, artifact, and attestation model.
+
+For the formal claims and residual risks, read the [Fence v0 specification](v0.md), [threat model](threat-model.md), and [security review](security-review.md). Report vulnerabilities according to the repository [security policy](../SECURITY.md).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,35 @@
+# Troubleshooting
+
+Fence prints a short progress log during setup and a compact **Fence Summary** with control and network-activity tables at the end of the job.
+
+## Enable Action Debug Logging
+
+If setup fails and you need more detail, set the standard GitHub Actions repository secret `ACTIONS_STEP_DEBUG` to `true` and rerun the job. Debug output includes bounded transient-service status and Fence-specific diagnostics while avoiding raw configuration bodies, environment values, packet payloads, and unrelated system logs.
+
+## Check The Supported Runner
+
+Fence's protected target is a GitHub-hosted `ubuntu-24.04` x64 host job. A job using `ubuntu-latest`, another architecture, a container job, or a self-hosted runner may fail the support check or may not establish the protected lifecycle.
+
+Fence must be the first meaningful step in the job. Move checkout, setup actions, and workflow commands after Fence so the Action can validate the expected runner state before other code changes it.
+
+## Investigate A Blocked Destination
+
+Start with `mode: audit` and inspect the final **Fence Summary**. Add the narrowest exact hostname, protocol, and port that the workflow needs, then return to `block` mode. Avoid broad wildcard suffixes when a small set of exact hostnames is sufficient.
+
+If a hostname is allowlisted but still fails, check whether the service redirects to a different hostname, uses a CDN or object-storage domain, or opens a non-default port. Container image pulls commonly span authentication, registry, layer, CDN, and storage destinations.
+
+## Investigate Container Failures
+
+Standard block mode intentionally disables Docker and containerd control paths. Workflows that require containers must set `container_policy: unsafe_preserve` and accept that the result no longer carries the standard containment claim.
+
+## Investigate Critical Drift
+
+A critical finding after readiness is permanent for that Fence lifecycle. The post-job hook fails the job because a required worker exited, an owned firewall object changed, a privilege or container control drifted, an unexpected root control endpoint appeared, or another verified invariant stopped holding.
+
+Do not paper over a critical drift failure with a broader network allowlist. Use the summary and debug diagnostics to identify the failed control, then compare it with the [supported security boundary](security.md) and [normative v0 contract](v0.md).
+
+## Direct Agent Execution
+
+`fence render-plan` and `fence check-support` are inspection commands. An ordinary direct `fence run` is rejected with `trusted_launcher_required`; production activation must come through the checked-in Action and matching transient systemd service.
+
+See the [CLI reference](cli.md) for command details.


### PR DESCRIPTION
## Summary

Streamline the main README into a concise overview with a one-line quick start, expanded examples, compact allowlist and security guidance, and a high-level architecture diagram.

Move detailed setup, syntax, lifecycle, security, release provenance, troubleshooting, local development, and CLI material into focused pages under `docs/`, with direct read-more links from the README.
