### PR TITLE
Release v0.8.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "fence"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "clap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fence"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2024"
 rust-version = "1.96.1"
 


### PR DESCRIPTION
Bumps Fence to `v0.8.3` so the next release uses the new Dependabot-friendly Action pin. The published example will include the full Action SHA and `# pin@v0.8.3`.