### PR TITLE
Simplify README tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![main / ubuntu-latest](https://github.com/openai/fence/actions/workflows/action-acceptance-ubuntu-latest.yml/badge.svg?branch=main&event=schedule)](https://github.com/openai/fence/actions/workflows/action-acceptance-ubuntu-latest.yml?query=branch%3Amain+event%3Aschedule)
 [![integration](https://github.com/openai/fence/actions/workflows/integration.yml/badge.svg)](https://github.com/openai/fence/actions/workflows/integration.yml)
 
-Fence runs first in a GitHub Actions job, applies a bounded built-in GitHub Actions and hosted-runner platform policy plus your `allowlist`, blocks other outbound network access, and turns off passwordless sudo and Docker by default.
+A GitHub Action for hardening CI/CD pipelines with bounded egress filtering and runner lockdown.
 
 ![Fence](./docs/assets/fence.png)
 


### PR DESCRIPTION
Replace the dense README introduction with a concise tagline focused on bounded egress filtering and runner lockdown.
