### PR TITLE
Enforce native Action allowlist entry limit

### DIFF
--- a/action/lib.cts
+++ b/action/lib.cts
@@ -97,6 +97,7 @@ const FORWARDED_DNS_QUERY_TYPES = new Set(["a", "aaaa"]);
 const INVOCATION_ID = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const DNS_HOSTNAME = /^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)*[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
 const RESULTS_STORAGE_HOSTNAME = /^productionresultssa[0-9]{1,5}\.blob\.core\.windows\.net$/;
+const MAX_ALLOWLIST_ENTRIES = 64;
 const MAX_RESULTS_STORAGE_AUTHORIZATIONS = 4;
 const MAX_USER_WILDCARD_AUTHORIZATIONS = 8;
 const MAX_USER_WILDCARD_PREFIX_LABELS = 2;
@@ -507,6 +508,9 @@ function parseAllowlistInput(value: unknown): AllowlistEntry[] {
       const message = error instanceof Error ? error.message : String(error);
       fail(`allowlist line ${index + 1}: ${message}`);
     }
+  }
+  if (entries.length > MAX_ALLOWLIST_ENTRIES) {
+    fail(`allowlist input must contain no more than ${MAX_ALLOWLIST_ENTRIES} unique entries`);
   }
   return entries;
 }

--- a/action/test.cts
+++ b/action/test.cts
@@ -342,6 +342,21 @@ test("normalizes canonical IPv4 and IPv6 allowlist networks", () => {
   }
 });
 
+test("enforces the native allowlist entry limit after deduplication", () => {
+  const environment = { GITHUB_RUN_ID: "12345", GITHUB_RUN_ATTEMPT: "2" };
+  const entries = Array.from({ length: 64 }, (_, index) => `host-${index}.example.com`);
+  const allowlistLength = (allowlist: string[]): number => JSON.parse(
+    defaultInlineConfig(environment, { allowlist: allowlist.join("\n") }),
+  ).allowlist.length;
+
+  assert.equal(allowlistLength(entries), 64);
+  assert.throws(
+    () => allowlistLength([...entries, "host-64.example.com"]),
+    /allowlist input must contain no more than 64 unique entries/,
+  );
+  assert.equal(allowlistLength([...entries, entries[0]]), 64);
+});
+
 test("formats concise setup and ready logs without raw evidence fields", () => {
   const details = actionLog.configLogDetails(
     JSON.stringify({


### PR DESCRIPTION
## Why

The Rust configuration parser already defines `MAX_ALLOWANCES = 64` and rejects larger serialized allowlist arrays with `too_many_allowlist_entries` before normalization. The native Action parser deduplicates its input but currently does not enforce that existing limit.

Reproduced on current `main`: 65 unique native entries are accepted and serialized by the wrapper, then rejected by the Rust parser during privileged setup. This change does not introduce a new 64-entry policy; it mirrors the existing runtime contract in the native input path so invalid input fails earlier and more directly.

## Changes

- reject native Action allowlists with more than 64 unique entries
- apply the limit after deduplication so duplicate lines retain their existing behavior
- cover the 64-entry boundary, 65 unique entries, and 65 lines containing one duplicate

## Reproduction

| Native input | Serialized entries | Result |
| --- | ---: | --- |
| 64 unique entries | 64 | accepted |
| 65 unique entries | 65 | rejected early by this change |
| 65 lines containing 64 unique entries | 64 | accepted |

## Tests

- `script/lint`
- `script/test`
- `script/test-action-wrapper`