### PR TITLE
docs: clarify default GitHub Actions egress

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,9 @@ Fence reduces where later workflow steps can send data and removes common ways t
 
 Activation fails closed unless the live host matches Fence's reviewed fingerprint. Sudo policy files remain byte-exact except for the first line of `90-cloud-init-users`, which must match cloud-init's generated version/timestamp header; Fence hashes every remaining byte and retains a raw whole-file runtime pin so later changes are still detected.
 
-The built-in GitHub destinations are a compatibility tradeoff because later workflow code can also reach them. GitHub results-storage accounts remain restricted to the reviewed runner authorization path, including when another allowed hostname returns a CNAME. Pin Fence to the full immutable `action_commit` SHA from a release, use `disable_broad_github_domains: true` when the narrower GitHub path is sufficient, and treat `container_policy: unsafe_preserve` as a deliberately weaker mode.
+Fence keeps a small set of GitHub Actions destinations open so your job can run and report results. The default policy includes up to eight `*.githubapp.com` hostnames and one fixed results-storage account, `productionresultssa19.blob.core.windows.net`. Up to four additional results-storage accounts are allowed only when requested by the verified GitHub runner. Later workflow steps can also reach allowed destinations.
+
+Set `disable_broad_github_domains: true` to remove optional GitHub destinations when your workflow does not need them. The fixed results-storage account remains available for runner compatibility. Pin Fence to the full immutable `action_commit` SHA from a release, and treat `container_policy: unsafe_preserve` as a deliberately weaker mode.
 
 **Read more:** [Security boundaries and operational guidance](docs/security.md)
 


### PR DESCRIPTION
Clarify the built-in GitHub Actions egress policy in the README. Document the fixed results-storage compatibility account, bounded GitHub app destinations, and the runner verification required for additional storage accounts.