### PR TITLE
ci: harden protected finalization timing

### DIFF
--- a/.github/workflows/action-acceptance.yml
+++ b/.github/workflows/action-acceptance.yml
@@ -430,6 +430,7 @@ jobs:
           fi
 
       - name: activate bundled Fence agent without post-ready warming
+        timeout-minutes: 3
         uses: ./
         with:
           invocation_id: action-finalization-${{ matrix.replica }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -154,7 +154,7 @@ jobs:
       fail-fast: false
       matrix:
         replica: [quiet-1, quiet-2, quiet-3]
-    timeout-minutes: 3
+    timeout-minutes: 8
     runs-on: ubuntu-24.04
 
     steps:
@@ -173,6 +173,7 @@ jobs:
         run: script/bootstrap
 
       - name: run quiet packaged trusted-launcher block
+        timeout-minutes: 3
         run: script/test-protected-run standard-finalization
 
   integration:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,7 +138,7 @@ All scripts live in `script/` and should use `set -euo pipefail` unless there is
 - `script/test`
   - Validates the release-tool lockfile and manifest before running tests.
   - Validates the test-tool lockfile and manifest before running tests.
-  - Runs the offline Action release-state regression suite before Rust tests.
+  - Runs the offline Action release-state and protected-finalization regression suites before Rust tests.
   - Runs `cargo test --frozen` by default.
   - `--coverage`, `--cov`, or `-c` requires `cargo-llvm-cov` from `script/install-test-tools` and `llvm-tools-preview` from `script/prepare-rust`.
   - Coverage mode writes text, JSON, LCOV, and HTML reports under `coverage/`.
@@ -187,12 +187,12 @@ All scripts live in `script/` and should use `set -euo pipefail` unless there is
   - Runs `wildcard-docker` with `unsafe_preserve` to prove exact-depth `*.docker.io` user policy authorizes concrete registry names lazily, retains Docker access, and emits bounded user-origin materialization evidence without claiming that every Docker layer CDN is covered.
   - Runs `malformed-wildcard` to prove a three-label wildcard is rejected by the source agent under the trusted launcher before Fence writes readiness or state, creates its nftables table, disables sudo, or changes Docker availability.
   - Runs `audit` to prove owned non-blocking observation rules emit bounded `would_block` findings with local process attribution when ownership remains observable, while passwordless sudo, Docker access, and arbitrary traffic remain available without a containment claim.
-  - Runs three quiet `standard-finalization` replicas without artificial post-ready network warming. A downstream verifier must prove each reaches terminal success within 180 seconds and exposes a nonempty downloadable job-log archive.
+  - Runs three quiet `standard-finalization` replicas without artificial post-ready network warming. Each replica has an eight-minute job budget for checkout, runner observation, Rust preparation, and bootstrap; its protected activation step has a three-minute timeout. A downstream read-only verifier must prove successful terminal job completion, including post hooks, within 180 seconds of the protected activation step's start and verify a nonempty downloadable job-log archive.
   - Leaves applied state resident until ephemeral runner teardown. It must not restore access, intentionally initiate optional post-ready artifact/cache/API operations, or claim support beyond the reviewed paths.
 
 - `script/verify-protected-finalization`
   - GitHub-Actions-only downstream verifier for either the quiet protected-run replicas plus broad-domain opt-out scenario or the quiet bundled-Action replicas selected by its fixed argument.
-  - Uses a read-only Actions token to inspect only the current workflow run, requires the expected jobs to finish successfully within 180 seconds, follows the job-log redirect without forwarding the bearer token, and verifies each bounded downloaded log payload is nonempty. A naturally observed runner-authorized results-storage request is additional evidence rather than a required event because the runner may resolve or establish that path before Fence readiness or after the final readable report snapshot.
+  - Uses a read-only Actions token to inspect only the current workflow run, requires each expected job and its exact protected activation step to succeed, verifies successful terminal job completion, including Action post hooks, within 180 seconds of that step's start, follows the job-log redirect without forwarding the bearer token, and verifies each bounded downloaded log payload is nonempty. Checkout and setup remain outside the 180-second security timer and inside the bounded eight-minute job budget. A naturally observed runner-authorized results-storage request is additional evidence rather than a required event because the runner may resolve or establish that path before Fence readiness or after the final readable report snapshot.
   - Accepts only bounded HTTPS redirects to reviewed GitHub Actions, GitHub content, or Azure Blob host suffixes. It must not print signed URLs, query strings, tokens, archive contents, or unrelated job metadata.
 
 - `script/observe-hosted-runner`

--- a/docs/v0.md
+++ b/docs/v0.md
@@ -1526,13 +1526,7 @@ The `integration` workflow runs separately and only on the intended `ubuntu-24.0
   owned non-blocking network rules verify while sudo and container paths
   remain available, and leave applied state resident for terminal hosted
   completion; and
-- run three quiet standard-block finalization replicas with no artificial
-  post-ready traffic, then use a downstream read-only verifier to require
-  terminal success within 180 seconds and a nonempty downloadable job-log
-  payload for each replica. Record a naturally observed runner-authorized
-  results-storage request as additional evidence when it occurs, but do not
-  require one: the runner may establish or resolve its upload path before
-  Fence readiness or request it after the final readable report snapshot; and
+- run three quiet standard-block finalization replicas with no artificial post-ready traffic. Give each replica an eight-minute job budget for checkout, runner observation, Rust preparation, and bootstrap, and impose a separate three-minute timeout on protected activation. Use a downstream read-only verifier to require successful terminal job completion, including post hooks, within 180 seconds of the protected activation step's start and a nonempty downloadable job-log payload for each replica. Checkout and setup remain outside the 180-second security timer. Record a naturally observed runner-authorized results-storage request as additional evidence when it occurs, but do not require one: the runner may establish or resolve its upload path before Fence readiness or request it after the final readable report snapshot; and
 - avoid release or deployment credentials.
 
 The selected-profile runtime scenario supplies a required
@@ -1668,7 +1662,7 @@ On `ubuntu-24.04` x64, the packaged public-contract workflow must prove:
 
 ### Bundled Action Acceptance Tests
 
-On disposable GitHub-hosted `ubuntu-24.04` x64 runners, the reusable root Action workflow must prove the same contract for an ephemeral source-built candidate during pull-request and ordinary `main` validation and for exact distribution commit `D` during release validation. It schedules each unique end-to-end behavior once: zero-input standard block, standard block with broad GitHub domains disabled, degraded wildcard-Docker compatibility, nested-layout audit, setup rejection, and post-ready tamper detection. Three quiet standard-block finalization replicas remain separate to preserve repeated no-restore terminal evidence. Together these cases retain coverage of every supported mode and failure boundary without redundant explicit standard, degraded, or audit matrix entries:
+On disposable GitHub-hosted `ubuntu-24.04` x64 runners, the reusable root Action workflow must prove the same contract for an ephemeral source-built candidate during pull-request and ordinary `main` validation and for exact distribution commit `D` during release validation. It schedules each unique end-to-end behavior once: zero-input standard block, standard block with broad GitHub domains disabled, degraded wildcard-Docker compatibility, nested-layout audit, setup rejection, and post-ready tamper detection. Three quiet standard-block finalization replicas remain separate to preserve repeated no-restore terminal evidence. Each replica has an eight-minute job budget for checkout and setup, a three-minute protected activation-step timeout, and a downstream read-only verifier that requires successful job completion, including Action post hooks, within 180 seconds of that step's start. Together these cases retain coverage of every supported mode and failure boundary without redundant explicit standard, degraded, or audit matrix entries:
 
 - `script/validate-action-bundle --root <candidate-root>` validates schema `4`, stable/prerelease agreement, source/signer identity, bundle path, and binary digest without network access;
 - `uses: ./` validates the mode-`0644` bundle bytes, copies them to a protected root-owned mode-`0555` path, and launches only that copy without downloading an agent or fetching policy at runtime;

--- a/script/lib/protected_finalization.py
+++ b/script/lib/protected_finalization.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+
+import copy
+import datetime
+import sys
+import unittest
+
+
+MAX_PROTECTED_SECONDS = 180
+EXPECTED_FINALIZATION_STEPS = {
+    "integration": {
+        "protected finalization quiet-1": "run quiet packaged trusted-launcher block",
+        "protected finalization quiet-2": "run quiet packaged trusted-launcher block",
+        "protected finalization quiet-3": "run quiet packaged trusted-launcher block",
+        "protected standard-opt-out required": "run packaged trusted-launcher block",
+    },
+    "action": {
+        "action finalization quiet-1": "activate bundled Fence agent without post-ready warming",
+        "action finalization quiet-2": "activate bundled Fence agent without post-ready warming",
+        "action finalization quiet-3": "activate bundled Fence agent without post-ready warming",
+    },
+}
+
+
+def _timestamp(value, description):
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"protected finalization {description} timestamp was invalid")
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    try:
+        parsed = datetime.datetime.fromisoformat(value)
+    except (TypeError, ValueError, OverflowError):
+        raise ValueError(
+            f"protected finalization {description} timestamp was invalid"
+        ) from None
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError(f"protected finalization {description} timestamp was invalid")
+    return parsed
+
+
+def _successful_step(step, job_name, description):
+    if step.get("status") != "completed" or step.get("conclusion") != "success":
+        raise ValueError(
+            f"protected finalization {description} did not complete successfully: "
+            f"{job_name}"
+        )
+    started = _timestamp(step.get("started_at"), f"{description} start for {job_name}")
+    completed = _timestamp(
+        step.get("completed_at"), f"{description} completion for {job_name}"
+    )
+    if completed < started:
+        raise ValueError(
+            f"protected finalization {description} timestamps were out of order: "
+            f"{job_name}"
+        )
+    return started, completed
+
+
+def validate_finalization_jobs(document, job_set):
+    if not isinstance(job_set, str) or job_set not in EXPECTED_FINALIZATION_STEPS:
+        raise ValueError("protected finalization job set was invalid")
+    if not isinstance(document, dict) or not isinstance(document.get("jobs"), list):
+        raise ValueError("protected finalization job metadata was invalid")
+
+    expected = EXPECTED_FINALIZATION_STEPS[job_set]
+    jobs = {}
+
+    for job in document["jobs"]:
+        if not isinstance(job, dict) or not isinstance(job.get("name"), str):
+            raise ValueError("protected finalization job metadata was invalid")
+        observed_name = job["name"]
+        matches = [
+            name
+            for name in expected
+            if observed_name == name or observed_name.endswith(f" / {name}")
+        ]
+        if not matches:
+            continue
+        if len(matches) != 1:
+            raise ValueError(
+                f"protected finalization job name was ambiguous: {observed_name}"
+            )
+
+        name = matches[0]
+        if observed_name != name:
+            prefix = observed_name[: -(len(name) + 3)]
+            if (
+                not prefix
+                or len(prefix) > 128
+                or any(ord(character) < 0x20 or ord(character) == 0x7F for character in prefix)
+            ):
+                raise ValueError(
+                    "protected finalization reusable-workflow prefix was invalid: "
+                    f"{observed_name}"
+                )
+        if name in jobs:
+            raise ValueError(f"protected finalization job was duplicated: {name}")
+        jobs[name] = job
+
+    missing = sorted(set(expected) - set(jobs))
+    if missing:
+        raise ValueError(
+            f"protected finalization jobs were not observable: {', '.join(missing)}"
+        )
+
+    for name, job in jobs.items():
+        job_id = job.get("id")
+        if not isinstance(job_id, int) or isinstance(job_id, bool) or job_id <= 0:
+            raise ValueError(f"protected finalization job identifier was invalid: {name}")
+        if job.get("status") != "completed" or job.get("conclusion") != "success":
+            raise ValueError(
+                f"protected finalization job did not complete successfully: {name}"
+            )
+
+        started = _timestamp(job.get("started_at"), f"job start for {name}")
+        completed = _timestamp(job.get("completed_at"), f"job completion for {name}")
+        steps = job.get("steps")
+        if not isinstance(steps, list) or any(not isinstance(step, dict) for step in steps):
+            raise ValueError(f"protected finalization job steps were invalid: {name}")
+
+        activation_name = expected[name]
+        activations = [step for step in steps if step.get("name") == activation_name]
+        if len(activations) != 1:
+            raise ValueError(
+                f"protected finalization activation step was missing or duplicated: {name}"
+            )
+        activated, activation_completed = _successful_step(
+            activations[0], name, "activation step"
+        )
+        if not started <= activated <= activation_completed <= completed:
+            raise ValueError(
+                f"protected finalization job and activation timestamps were out of order: "
+                f"{name}"
+            )
+        if (completed - activated).total_seconds() > MAX_PROTECTED_SECONDS:
+            raise ValueError(f"protected finalization exceeded 180 seconds: {name}")
+
+        post_steps = [
+            step for step in steps if step.get("name") == f"Post {activation_name}"
+        ]
+        if job_set == "action" and not post_steps:
+            raise ValueError(f"protected finalization post hook was missing: {name}")
+        if len(post_steps) > 1:
+            raise ValueError(f"protected finalization post hook was duplicated: {name}")
+        if post_steps:
+            post_started, post_completed = _successful_step(
+                post_steps[0], name, "post hook"
+            )
+            if not activation_completed <= post_started <= post_completed <= completed:
+                raise ValueError(
+                    f"protected finalization post-hook timestamps were out of order: {name}"
+                )
+
+    return jobs
+
+
+class ProtectedFinalizationTests(unittest.TestCase):
+    def document(self, job_set="integration", protected_seconds=45, setup_seconds=155):
+        base = datetime.datetime(2026, 7, 23, tzinfo=datetime.timezone.utc)
+        activated = base + datetime.timedelta(seconds=setup_seconds)
+        completed = activated + datetime.timedelta(seconds=protected_seconds)
+        activation_completed = activated + datetime.timedelta(
+            seconds=min(20, protected_seconds)
+        )
+
+        def timestamp(value):
+            return value.isoformat().replace("+00:00", "Z")
+
+        jobs = []
+        for job_id, (name, activation_name) in enumerate(
+            EXPECTED_FINALIZATION_STEPS[job_set].items(), start=1
+        ):
+            activation = {
+                "name": activation_name,
+                "status": "completed",
+                "conclusion": "success",
+                "started_at": timestamp(activated),
+                "completed_at": timestamp(activation_completed),
+            }
+            post = {
+                "name": f"Post {activation_name}",
+                "status": "completed",
+                "conclusion": "success",
+                "started_at": timestamp(activation_completed),
+                "completed_at": timestamp(completed),
+            }
+            jobs.append(
+                {
+                    "id": job_id,
+                    "name": name,
+                    "status": "completed",
+                    "conclusion": "success",
+                    "started_at": timestamp(base),
+                    "completed_at": timestamp(completed),
+                    "steps": [activation, post],
+                }
+            )
+        return {"jobs": jobs}
+
+    def test_slow_setup_does_not_consume_the_protected_budget(self):
+        for job_set in EXPECTED_FINALIZATION_STEPS:
+            with self.subTest(job_set=job_set):
+                document = self.document(job_set, setup_seconds=155)
+                self.assertEqual(
+                    set(validate_finalization_jobs(document, job_set)),
+                    set(EXPECTED_FINALIZATION_STEPS[job_set]),
+                )
+
+    def test_180_seconds_pass_and_181_seconds_fail(self):
+        for job_set in EXPECTED_FINALIZATION_STEPS:
+            with self.subTest(job_set=job_set, seconds=180):
+                validate_finalization_jobs(self.document(job_set, 180), job_set)
+            with self.subTest(job_set=job_set, seconds=181):
+                with self.assertRaisesRegex(ValueError, "exceeded 180 seconds"):
+                    validate_finalization_jobs(self.document(job_set, 181), job_set)
+
+    def test_all_exact_activation_mappings_are_required(self):
+        for job_set, expected in EXPECTED_FINALIZATION_STEPS.items():
+            for name in expected:
+                with self.subTest(job_set=job_set, name=name):
+                    document = self.document(job_set)
+                    job = next(item for item in document["jobs"] if item["name"] == name)
+                    job["steps"][0]["name"] += " renamed"
+                    with self.assertRaisesRegex(ValueError, "activation step"):
+                        validate_finalization_jobs(document, job_set)
+
+    def test_reusable_workflow_prefixes_are_bounded(self):
+        for job_set in EXPECTED_FINALIZATION_STEPS:
+            with self.subTest(job_set=job_set):
+                document = self.document(job_set)
+                for job in document["jobs"]:
+                    job["name"] = f"release verification / {job['name']}"
+                self.assertEqual(
+                    set(validate_finalization_jobs(document, job_set)),
+                    set(EXPECTED_FINALIZATION_STEPS[job_set]),
+                )
+        for prefix in ("", "x" * 129, "bad\nname", "bad\x7fname"):
+            with self.subTest(prefix=repr(prefix)):
+                document = self.document()
+                document["jobs"][0]["name"] = (
+                    f"{prefix} / {document['jobs'][0]['name']}"
+                )
+                with self.assertRaisesRegex(ValueError, "prefix was invalid"):
+                    validate_finalization_jobs(document, "integration")
+
+    def test_missing_or_duplicate_jobs_fail_closed(self):
+        document = self.document()
+        document["jobs"].pop()
+        with self.assertRaisesRegex(ValueError, "not observable"):
+            validate_finalization_jobs(document, "integration")
+
+        document = self.document()
+        duplicate = copy.deepcopy(document["jobs"][0])
+        duplicate["name"] = f"reusable / {duplicate['name']}"
+        document["jobs"].append(duplicate)
+        with self.assertRaisesRegex(ValueError, "job was duplicated"):
+            validate_finalization_jobs(document, "integration")
+
+    def test_jobs_and_activation_steps_must_succeed(self):
+        for field, value in (
+            ("status", "queued"),
+            ("status", "in_progress"),
+            ("conclusion", "failure"),
+            ("conclusion", "cancelled"),
+            ("conclusion", "skipped"),
+            ("conclusion", None),
+        ):
+            for target in ("job", "activation"):
+                with self.subTest(target=target, field=field, value=value):
+                    document = self.document()
+                    record = document["jobs"][0]
+                    if target == "activation":
+                        record = record["steps"][0]
+                    record[field] = value
+                    with self.assertRaisesRegex(ValueError, "complete successfully"):
+                        validate_finalization_jobs(document, "integration")
+
+    def test_post_hooks_must_succeed_within_the_protected_window(self):
+        for field, value in (
+            ("status", "in_progress"),
+            ("conclusion", "failure"),
+            ("conclusion", "cancelled"),
+            ("conclusion", "skipped"),
+        ):
+            with self.subTest(field=field, value=value):
+                document = self.document("action")
+                document["jobs"][0]["steps"][1][field] = value
+                with self.assertRaisesRegex(ValueError, "post hook"):
+                    validate_finalization_jobs(document, "action")
+
+        document = self.document("action")
+        post = document["jobs"][0]["steps"][1]
+        post["completed_at"] = "2026-07-23T00:03:21Z"
+        with self.assertRaisesRegex(ValueError, "post-hook timestamps"):
+            validate_finalization_jobs(document, "action")
+
+    def test_action_post_hook_is_required_and_integration_post_is_optional(self):
+        document = self.document("action")
+        document["jobs"][0]["steps"].pop(1)
+        with self.assertRaisesRegex(ValueError, "post hook was missing"):
+            validate_finalization_jobs(document, "action")
+
+        document = self.document("integration")
+        for job in document["jobs"]:
+            job["steps"].pop(1)
+        validate_finalization_jobs(document, "integration")
+
+    def test_post_steps_cannot_be_mistaken_for_activation(self):
+        document = self.document("action")
+        document["jobs"][0]["steps"].pop(0)
+        with self.assertRaisesRegex(ValueError, "activation step"):
+            validate_finalization_jobs(document, "action")
+
+        document = self.document("action")
+        document["jobs"][0]["steps"].append(
+            copy.deepcopy(document["jobs"][0]["steps"][0])
+        )
+        with self.assertRaisesRegex(ValueError, "activation step"):
+            validate_finalization_jobs(document, "action")
+
+        document = self.document("action")
+        document["jobs"][0]["steps"].append(
+            copy.deepcopy(document["jobs"][0]["steps"][1])
+        )
+        with self.assertRaisesRegex(ValueError, "post hook was duplicated"):
+            validate_finalization_jobs(document, "action")
+
+    def test_invalid_and_timezone_naive_timestamps_are_rejected(self):
+        invalid_values = (
+            None,
+            "",
+            "not-a-timestamp",
+            "2026-07-23T00:00:00",
+            "2026-07-23T00:00:00+25:00",
+            123,
+        )
+        for target in ("job", "activation", "post"):
+            for field in ("started_at", "completed_at"):
+                for value in invalid_values:
+                    with self.subTest(target=target, field=field, value=value):
+                        document = self.document("action")
+                        if target == "job":
+                            record = document["jobs"][0]
+                        elif target == "activation":
+                            record = document["jobs"][0]["steps"][0]
+                        else:
+                            record = document["jobs"][0]["steps"][1]
+                        record[field] = value
+                        with self.assertRaisesRegex(ValueError, "timestamp was invalid"):
+                            validate_finalization_jobs(document, "action")
+
+    def test_reversed_timestamps_are_rejected(self):
+        cases = (
+            ("job", "started_at", "2026-07-23T00:03:00Z"),
+            ("job", "completed_at", "2026-07-23T00:02:30Z"),
+            ("activation", "started_at", "2026-07-23T00:04:00Z"),
+            ("activation", "completed_at", "2026-07-23T00:02:00Z"),
+            ("post", "started_at", "2026-07-23T00:02:00Z"),
+            ("post", "completed_at", "2026-07-23T00:02:00Z"),
+        )
+        for target, field, value in cases:
+            with self.subTest(target=target, field=field):
+                document = self.document("action")
+                if target == "job":
+                    record = document["jobs"][0]
+                elif target == "activation":
+                    record = document["jobs"][0]["steps"][0]
+                else:
+                    record = document["jobs"][0]["steps"][1]
+                record[field] = value
+                with self.assertRaisesRegex(ValueError, "out of order"):
+                    validate_finalization_jobs(document, "action")
+
+    def test_invalid_metadata_and_job_identifiers_are_rejected(self):
+        for document in (None, [], {}, {"jobs": None}, {"jobs": [None]}):
+            with self.subTest(document=repr(document)):
+                with self.assertRaisesRegex(ValueError, "metadata was invalid"):
+                    validate_finalization_jobs(document, "integration")
+
+        for job_id in (None, 0, -1, True, "1"):
+            with self.subTest(job_id=job_id):
+                document = self.document()
+                document["jobs"][0]["id"] = job_id
+                with self.assertRaisesRegex(ValueError, "identifier was invalid"):
+                    validate_finalization_jobs(document, "integration")
+
+        for steps in (None, {}, [None]):
+            with self.subTest(steps=repr(steps)):
+                document = self.document()
+                document["jobs"][0]["steps"] = steps
+                with self.assertRaisesRegex(ValueError, "steps were invalid"):
+                    validate_finalization_jobs(document, "integration")
+
+        for job_set in (None, "", "unknown", 1, []):
+            with self.subTest(job_set=repr(job_set)):
+                with self.assertRaisesRegex(ValueError, "job set was invalid"):
+                    validate_finalization_jobs(self.document(), job_set)
+
+
+if __name__ == "__main__":
+    if sys.argv[1:] != ["--self-test"]:
+        raise SystemExit("usage: protected_finalization.py --self-test")
+    program = unittest.main(argv=[sys.argv[0]], exit=False)
+    raise SystemExit(0 if program.result.wasSuccessful() else 1)

--- a/script/test
+++ b/script/test
@@ -9,6 +9,7 @@ ensure_rust_toolchain
 script/validate-release-tools
 script/validate-test-tools
 script/test-action-release
+python3 -B -E "$DIR/script/lib/protected_finalization.py" --self-test
 script/test-rust-toolchain-preparation
 
 case "${1:-}" in

--- a/script/validate-locks
+++ b/script/validate-locks
@@ -1317,8 +1317,8 @@ require(
 finalization_activation = require_step_contract(
     action_job_blocks["action-finalization"],
     "activate bundled Fence agent without post-ready warming",
-    ["uses", "with"],
-    {"uses": "./"},
+    ["timeout-minutes", "uses", "with"],
+    {"timeout-minutes": "3", "uses": "./"},
     "Action acceptance finalization activation",
 )
 finalization_activation_with = indented_block(
@@ -1339,8 +1339,9 @@ finalization = indented_block(
 )
 require(
     "replica: [quiet-1, quiet-2, quiet-3]" in finalization
-    and "fail-fast: false" in finalization,
-    "Action acceptance must retain three non-cancelling finalization replicas",
+    and "fail-fast: false" in finalization
+    and scalar_mapping(finalization, 4).get("timeout-minutes") == "8",
+    "Action acceptance must retain three non-cancelling finalization replicas with an eight-minute setup budget",
 )
 
 require_exact_mapping_keys(
@@ -1633,7 +1634,7 @@ expected_target_timeouts = {
     "lockdown": "8",
     "selected-profile-runtime": "8",
     "protected-run": "8",
-    "protected-finalization": "3",
+    "protected-finalization": "8",
 }
 expected_integration_steps = {
     "lockdown": [
@@ -1868,8 +1869,11 @@ require(
 require_step_contract(
     protected_finalization,
     "run quiet packaged trusted-launcher block",
-    ["run"],
-    {"run": "script/test-protected-run standard-finalization"},
+    ["timeout-minutes", "run"],
+    {
+        "timeout-minutes": "3",
+        "run": "script/test-protected-run standard-finalization",
+    },
     "Integration protected finalization evidence",
 )
 

--- a/script/verify-protected-finalization
+++ b/script/verify-protected-finalization
@@ -21,36 +21,26 @@ fi
 
 require_cmd python3
 
-FENCE_FINALIZATION_JOB_SET="$job_set" python3 <<'PY'
-import datetime
+FENCE_FINALIZATION_JOB_SET="$job_set" python3 -B -E - "$DIR" <<'PY'
 import io
 import json
 import os
+import sys
 import time
 import urllib.error
 import urllib.request
 import urllib.parse
 import zipfile
 
+sys.path.insert(0, os.path.join(sys.argv[1], "script", "lib"))
+
+from protected_finalization import validate_finalization_jobs
+
 repository = os.environ["GITHUB_REPOSITORY"]
 run_id = os.environ["GITHUB_RUN_ID"]
 token = os.environ["GITHUB_TOKEN"]
 job_set = os.environ["FENCE_FINALIZATION_JOB_SET"]
 api_root = f"https://api.github.com/repos/{repository}"
-expected_jobs = (
-    {
-        "protected finalization quiet-1",
-        "protected finalization quiet-2",
-        "protected finalization quiet-3",
-        "protected standard-opt-out required",
-    }
-    if job_set == "integration"
-    else {
-        "action finalization quiet-1",
-        "action finalization quiet-2",
-        "action finalization quiet-3",
-    }
-)
 authorization_marker = b"fence-results-storage-authorization-observed"
 authorization_observed = False
 
@@ -115,42 +105,13 @@ if len(body) > 1024 * 1024:
     raise SystemExit("protected finalization job metadata exceeded its fixed bound")
 document = json.loads(body)
 
-jobs = {}
-for job in document.get("jobs", []):
-    if not isinstance(job, dict) or not isinstance(job.get("name"), str):
-        continue
-    observed_name = job["name"]
-    matches = [
-        expected
-        for expected in expected_jobs
-        if observed_name == expected or observed_name.endswith(f" / {expected}")
-    ]
-    if not matches:
-        continue
-    if len(matches) != 1:
-        raise SystemExit(f"protected finalization job name was ambiguous: {observed_name}")
-    canonical_name = matches[0]
-    if observed_name != canonical_name:
-        prefix = observed_name[: -(len(canonical_name) + 3)]
-        if not prefix or len(prefix) > 128 or any(ord(character) < 0x20 for character in prefix):
-            raise SystemExit(f"protected finalization reusable-workflow prefix was invalid: {observed_name}")
-    if canonical_name in jobs:
-        raise SystemExit(f"protected finalization job was duplicated: {canonical_name}")
-    jobs[canonical_name] = job
+try:
+    jobs = validate_finalization_jobs(document, job_set)
+except ValueError as error:
+    raise SystemExit(str(error)) from None
 
-missing = sorted(expected_jobs - jobs.keys())
-if missing:
-    raise SystemExit(f"protected finalization jobs were not observable: {', '.join(missing)}")
-
-for name in sorted(expected_jobs):
+for name in sorted(jobs):
     job = jobs[name]
-    if job.get("status") != "completed" or job.get("conclusion") != "success":
-        raise SystemExit(f"protected finalization job did not complete successfully: {name}")
-    started = datetime.datetime.fromisoformat(job["started_at"].replace("Z", "+00:00"))
-    completed = datetime.datetime.fromisoformat(job["completed_at"].replace("Z", "+00:00"))
-    if (completed - started).total_seconds() > 180:
-        raise SystemExit(f"protected finalization job exceeded 180 seconds: {name}")
-
     archive = None
     for attempt in range(6):
         archive = log_archive(job["id"])


### PR DESCRIPTION
Separate GitHub-hosted runner setup from the 180-second protected-finalization deadline. Give finalization jobs an eight-minute setup budget, cap activation at three minutes, and verify exact activation through terminal job completion. Add deterministic fail-closed regressions and pin both integration and reusable Action-acceptance workflow contracts.