### PR TITLE
Release v0.8.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "fence"
-version = "0.8.9"
+version = "0.8.10"
 dependencies = [
  "clap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fence"
-version = "0.8.9"
+version = "0.8.10"
 edition = "2024"
 rust-version = "1.97.1"
 


### PR DESCRIPTION
Release v0.8.10 with reliable blocked-network reporting, resilient process attribution, and protected post-job evidence handling. Bump the package and root lockfile together so the existing protected release workflow can build, attest, and verify the release.