### PR TITLE
Release Fence v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "fence"
-version = "0.8.10"
+version = "0.9.0"
 dependencies = [
  "clap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fence"
-version = "0.8.10"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.97.1"
 


### PR DESCRIPTION
Bump the Fence source manifest and root lockfile to v0.9.0 to publish the five trusted GitHub storage endpoints, clearer Azure platform documentation, and more accurate network reporting.