### PR TITLE
Release v0.9.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "fence"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "clap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fence"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2024"
 rust-version = "1.97.1"
 


### PR DESCRIPTION
Authorize the v0.9.2 patch release for the DNS, runner compatibility, and Action configuration improvements already on main. Update only the matching Cargo package and lockfile versions; the protected release workflow will build, verify, and publish the release after merge.