### PR TITLE
docs: document report log retention

### DIFF
--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -53,6 +53,8 @@ gh api repos/OWNER/REPO/actions/jobs/JOB_ID/logs \
   | jq .
 ```
 
+Reports are retrievable only while the job log exists; GitHub applies a retention window to workflow logs, so consumers that need a durable record should capture the report when they observe it rather than re-fetching it later.
+
 The job log stores the report on one line. `jq` formats it like this:
 
 ```json


### PR DESCRIPTION
## Summary

Document that `FENCE_REPORT_JSON` remains retrievable only while the GitHub Actions job log exists.

## Why

The current fetch example reads the machine-readable report from the job log, but does not state that workflow logs are retained for a limited period. Consumers using a healthy block-mode report as durable evidence can otherwise discover later that the report can no longer be re-fetched.

## Change

Add one sentence next to the report-fetching example advising consumers that need durable evidence to capture the report while the log is still available.

No runtime or reporting behavior changes.

Closes #154