### PR TITLE
fix: bound DNS observation evidence in post hook

### DIFF
--- a/action/dns-evidence-bounds.test.cts
+++ b/action/dns-evidence-bounds.test.cts
@@ -3,6 +3,7 @@
 const assert = require("node:assert/strict");
 const test = require("node:test");
 const { validateDnsEvidence } = require("./lib.cts");
+const { validateDnsEvidenceBounds } = require("./post.cts");
 
 function residentHealth() {
   return {
@@ -70,6 +71,10 @@ function dnsEvidence(currentReport, overrides = {}) {
   };
 }
 
+function validateEvidence(evidence, currentReport) {
+  return validateDnsEvidenceBounds(validateDnsEvidence(evidence, currentReport));
+}
+
 test("bounds retained DNS observations to the Rust evidence limit", () => {
   const currentReport = report();
   const observations = Array.from({ length: 256 }, (_, index) => ({
@@ -77,12 +82,12 @@ test("bounds retained DNS observations to the Rust evidence limit", () => {
     policy_classification: "outside_policy",
   }));
 
-  assert.doesNotThrow(() => validateDnsEvidence(
+  assert.doesNotThrow(() => validateEvidence(
     dnsEvidence(currentReport, { observations }),
     currentReport,
   ));
   assert.throws(
-    () => validateDnsEvidence(
+    () => validateEvidence(
       dnsEvidence(currentReport, {
         observations: [
           ...observations,
@@ -91,7 +96,7 @@ test("bounds retained DNS observations to the Rust evidence limit", () => {
       }),
       currentReport,
     ),
-    /bounded DNS observation evidence/,
+    /retained DNS evidence bounds/,
   );
 });
 
@@ -99,7 +104,7 @@ test("bounds retained addresses per DNS observation", () => {
   const currentReport = report();
   const addresses = Array.from({ length: 32 }, (_, index) => `192.0.2.${index + 1}`);
 
-  assert.doesNotThrow(() => validateDnsEvidence(
+  assert.doesNotThrow(() => validateEvidence(
     dnsEvidence(currentReport, {
       observations: [{
         hostname: "api.example.com",
@@ -110,7 +115,7 @@ test("bounds retained addresses per DNS observation", () => {
     currentReport,
   ));
   assert.throws(
-    () => validateDnsEvidence(
+    () => validateEvidence(
       dnsEvidence(currentReport, {
         observations: [{
           hostname: "api.example.com",
@@ -120,6 +125,6 @@ test("bounds retained addresses per DNS observation", () => {
       }),
       currentReport,
     ),
-    /bounded DNS observation evidence/,
+    /retained DNS evidence bounds/,
   );
 });

--- a/action/dns-evidence-bounds.test.cts
+++ b/action/dns-evidence-bounds.test.cts
@@ -1,0 +1,125 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const { validateDnsEvidence } = require("./lib.cts");
+
+function residentHealth() {
+  return {
+    status: "healthy",
+    resident_pid: 4242,
+    verification_sequence: 9,
+    last_successful_verification_unix_milliseconds: Date.now() - 1_000,
+    verification_interval_seconds: 5,
+    workers: [
+      { name: "docker_tcp_dns", status: "running" },
+      { name: "docker_udp_dns", status: "running" },
+      { name: "host_tcp_dns", status: "running" },
+      { name: "host_udp_dns", status: "running" },
+      { name: "process_attribution", status: "running" },
+    ],
+  };
+}
+
+function report() {
+  return {
+    status: "protected_host_block",
+    mode: "block",
+    allow_github_artifacts: false,
+    platform_profile_id: "github_hosted_workflow_bootstrap_v5",
+    profile_realization_id: "github_hosted_workflow_bootstrap_dns_provenance_v5",
+    protection_available: true,
+    container_status: "disabled_verified",
+    resident_health: residentHealth(),
+  };
+}
+
+function dnsEvidence(currentReport, overrides = {}) {
+  return {
+    runtime_evidence_schema_version: 5,
+    status: currentReport.status,
+    mode: currentReport.mode,
+    allow_github_artifacts: currentReport.allow_github_artifacts,
+    platform_profile_id: currentReport.platform_profile_id,
+    profile_realization_id: currentReport.profile_realization_id,
+    protection_available: currentReport.protection_available,
+    resident_health: currentReport.resident_health,
+    routing_status: "active",
+    host_dns_routing: "direct_client_to_root_resident_mediator",
+    docker_dns_routing: "local_root_resident_mediator",
+    answer_attribution_status: "bounded_reportable_hostname_answers_only",
+    proxy_policy_status: "block_forwards_exact_roots_bounded_user_wildcard_names_actions_suffix_names_githubapp_suffix_names_results_storage_and_bounded_cname_descendants",
+    hostname_policy: {
+      exact: [],
+      user_wildcards: [],
+      allow_dynamic_githubapp_suffix: true,
+      allow_github_artifacts: false,
+    },
+    observations: [],
+    observations_truncated: false,
+    bounded_user_wildcard_authorizations: [],
+    bounded_user_wildcard_authorizations_truncated: false,
+    user_wildcard_request_rejections: 0,
+    runner_authorized_results_storage: [],
+    runner_authorized_results_storage_truncated: false,
+    results_storage_authorization_count: 0,
+    results_storage_attribution_failures: 0,
+    results_storage_request_rejections: 0,
+    limitations: [],
+    ...overrides,
+  };
+}
+
+test("bounds retained DNS observations to the Rust evidence limit", () => {
+  const currentReport = report();
+  const observations = Array.from({ length: 256 }, (_, index) => ({
+    hostname: `host-${index}.example.com`,
+    policy_classification: "outside_policy",
+  }));
+
+  assert.doesNotThrow(() => validateDnsEvidence(
+    dnsEvidence(currentReport, { observations }),
+    currentReport,
+  ));
+  assert.throws(
+    () => validateDnsEvidence(
+      dnsEvidence(currentReport, {
+        observations: [
+          ...observations,
+          { hostname: "host-256.example.com", policy_classification: "outside_policy" },
+        ],
+      }),
+      currentReport,
+    ),
+    /bounded DNS observation evidence/,
+  );
+});
+
+test("bounds retained addresses per DNS observation", () => {
+  const currentReport = report();
+  const addresses = Array.from({ length: 32 }, (_, index) => `192.0.2.${index + 1}`);
+
+  assert.doesNotThrow(() => validateDnsEvidence(
+    dnsEvidence(currentReport, {
+      observations: [{
+        hostname: "api.example.com",
+        policy_classification: "outside_policy",
+        resolved_addresses: addresses,
+      }],
+    }),
+    currentReport,
+  ));
+  assert.throws(
+    () => validateDnsEvidence(
+      dnsEvidence(currentReport, {
+        observations: [{
+          hostname: "api.example.com",
+          policy_classification: "outside_policy",
+          resolved_addresses: [...addresses, "198.51.100.1"],
+        }],
+      }),
+      currentReport,
+    ),
+    /bounded DNS observation evidence/,
+  );
+});

--- a/action/post.cts
+++ b/action/post.cts
@@ -36,6 +36,8 @@ const MANIFEST = path.join(ACTION_ROOT, "bundle-manifest.json");
 const EVIDENCE_SETTLE_INTERVAL_MILLISECONDS = 40;
 const EVIDENCE_SETTLE_MAX_READS = 4;
 const EVIDENCE_SETTLE_TIMEOUT_NANOSECONDS = 160_000_000n;
+const MAX_RETAINED_DNS_OBSERVATIONS = 256;
+const MAX_RETAINED_ADDRESSES_PER_OBSERVATION = 32;
 const CHILD_ENV = {
   LANG: "C.UTF-8",
   LC_ALL: "C.UTF-8",
@@ -97,6 +99,25 @@ function networkEvidenceCounters(report: any): { total: number; sampled: number 
     total: counters.total_violations,
     sampled: counters.sampled_violations,
   };
+}
+
+function validateDnsEvidenceBounds(dnsEvidence: any): any {
+  const observations = dnsEvidence?.observations;
+  if (!Array.isArray(observations) || observations.length > MAX_RETAINED_DNS_OBSERVATIONS) {
+    throw new Error("Fence DNS report exceeds retained DNS evidence bounds");
+  }
+  for (const observation of observations) {
+    if (
+      observation !== null &&
+      !Array.isArray(observation) &&
+      typeof observation === "object" &&
+      Array.isArray(observation.resolved_addresses) &&
+      observation.resolved_addresses.length > MAX_RETAINED_ADDRESSES_PER_OBSERVATION
+    ) {
+      throw new Error("Fence DNS report exceeds retained DNS evidence bounds");
+    }
+  }
+  return dnsEvidence;
 }
 
 function settleResidentReport(
@@ -225,10 +246,10 @@ function main(): void {
   let dnsEvidence;
   const effectiveDnsReportPath = dnsReportPath || paths.dnsReport;
   if (fs.existsSync(effectiveDnsReportPath)) {
-    dnsEvidence = validateDnsEvidence(
+    dnsEvidence = validateDnsEvidenceBounds(validateDnsEvidence(
       readJsonBounded(effectiveDnsReportPath, MAX_REPORT_BYTES, "Fence DNS report"),
       report,
-    );
+    ));
   } else if (report.mode === "block") {
     throw new Error("Fence block-mode DNS evidence is missing");
   }
@@ -337,4 +358,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { main, settleResidentReport };
+module.exports = { main, settleResidentReport, validateDnsEvidenceBounds };

--- a/script/test-action-wrapper
+++ b/script/test-action-wrapper
@@ -7,7 +7,7 @@ source script/env "$@"
 require_cmd node
 
 node -e 'require("./action/lib.cts"); require("./action/main.cts"); require("./action/post.cts")'
-node --test action/test.cts
+node --test action/test.cts action/dns-evidence-bounds.test.cts
 python3 -B -E script/lib/host_observation.py --self-test
 python3 -B -E script/lib/action_bundle_host.py --self-test
 script/test-action-bundle-provenance


### PR DESCRIPTION
## Summary

Bound DNS observation evidence in the protected Action post hook to the same retained limits enforced by the Rust DNS mediator.

## Problem

The Rust producer retains at most:

- 256 DNS observations
- 32 resolved addresses per observation

The Action validates the DNS evidence before using it for summaries and the machine-readable report, but did not independently enforce those producer-side collection bounds. A malformed evidence document could therefore pass the existing structural checks with larger arrays, as long as it stayed under the overall 4 MiB report limit.

## Evidence / reproduction

- The producer-side limits are fixed in `src/dns_mediator.rs` as `MAX_RETAINED_DNS_OBSERVATIONS = 256` and `MAX_RETAINED_ADDRESSES_PER_OBSERVATION = 32`.
- On the base commit, the protected post hook calls `validateDnsEvidence(...)`, but the existing validator has no equivalent cardinality check for `observations` or `resolved_addresses`.
- This creates a producer/consumer invariant gap: evidence containing 257 observations, or 33 retained addresses in one observation, is structurally representable to the Action even though the Rust producer cannot legitimately emit it.
- The regression in `action/dns-evidence-bounds.test.cts` exercises the exact boundaries: 256 is accepted and 257 rejected; 32 addresses are accepted and 33 rejected.
- `script/test-action-wrapper` includes the new regression so the protected wrapper contract is checked by the normal Action test entrypoint.

This is intentionally an independent validation in the post hook. The report is security evidence, so the consumer should reject states that are impossible under the trusted producer rather than relying only on the overall byte limit.

## Change

- Reject DNS evidence with more than 256 retained observations.
- Reject an observation with more than 32 retained resolved addresses.
- Add focused Node regression tests for both exact limits and the first over-limit case.
- Include the new regression file in `script/test-action-wrapper`.

This does not change the Rust evidence format or normal report contents. It tightens the protected post hook so it accepts only the bounded collection sizes the producer can legitimately emit.