### PR TITLE
fix: recover stale runtime report writes

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -387,6 +387,11 @@ fn replace_report(
 ) -> Result<(), RuntimeError> {
     let bytes = bounded_json(value)?;
     let pending = directory.join("report.json.next");
+    match fs::remove_file(&pending) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(io_error("runtime_atomic_write_failed", error)),
+    }
     write_bytes_exclusive(&pending, &bytes, 0o644)?;
     fs::rename(&pending, report).map_err(|error| io_error("runtime_atomic_write_failed", error))
 }
@@ -497,6 +502,28 @@ mod tests {
             fs::metadata(&store.report).unwrap().permissions().mode() & 0o777,
             0o644
         );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn recovers_from_stale_pending_report_file() {
+        let root = root();
+        let _ = fs::remove_dir_all(&root);
+        let store = TestRuntimeStore::create(&root, "resident-proof").unwrap();
+        let pending = store.directory.join("report.json.next");
+        fs::write(&pending, br#"{"value":"stale"}"#).unwrap();
+
+        store
+            .replace_report(&Document {
+                value: "fresh".to_owned(),
+            })
+            .unwrap();
+
+        assert_eq!(
+            fs::read_to_string(&store.report).unwrap(),
+            r#"{"value":"fresh"}"#
+        );
+        assert!(!pending.exists());
         fs::remove_dir_all(root).unwrap();
     }
 


### PR DESCRIPTION
## Summary

Recover resident report updates when a previous interrupted or failed atomic replacement leaves `report.json.next` behind.

## Problem

`replace_report` creates `report.json.next` with `create_new(true)` and then renames it over `report.json`. If an earlier write or rename fails after the pending path has been created, that path can remain in the runtime directory. Every later report update then fails immediately with `runtime_write_failed` because the exclusive create sees `AlreadyExists`.

This can prevent subsequent resident evidence updates even though the pending file is only an implementation detail of the atomic replacement path.

## Evidence / reproduction

- On the base commit, `src/runtime.rs::replace_report` computes `report.json.next`, calls the exclusive writer, and only then renames the pending file over `report.json`.
- The exclusive writer uses `create_new(true)`. Therefore any stale `report.json.next` left after an interrupted or failed prior replacement makes the next replacement fail with `AlreadyExists` before fresh evidence can be written.
- There is no base-commit cleanup of that pending path in `replace_report`, so the failure persists across every later replacement attempt rather than self-recovering.
- Minimal reproduction: create a runtime store, write any regular file at `<runtime>/report.json.next`, then call `replace_report` with a valid new report. On the base commit the exclusive create fails; deleting the stale implementation file manually makes the same update work again.
- The added `recovers_from_stale_pending_report_file` regression seeds exactly that stale file, replaces the report, verifies the fresh JSON, and verifies that the pending path is gone.

The cleanup deliberately ignores only `NotFound`. Permission, type, or other filesystem failures remain explicit errors, and the subsequent write still uses the existing exclusive/no-follow path before the atomic rename.

## Change

- remove a pre-existing `report.json.next` before starting the next atomic report replacement
- ignore only `NotFound`; surface other cleanup failures as `runtime_atomic_write_failed`
- preserve the existing exclusive `O_NOFOLLOW` write and atomic rename behavior
- add a regression test that seeds a stale pending report and verifies the next replacement succeeds and cleans it up

No policy, firewall, or report schema behavior changes.