### PR TITLE
fix: bound failure response output

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -68,8 +68,24 @@ pub fn failure(command: &str, error: ErrorDetail, exit_code: i32) -> CommandOutp
         data: None,
         error: Some(error),
     };
+    let json = serialize_envelope(&envelope);
+    let json = if json.len() > MAX_REPORT_BYTES {
+        serialize_envelope(&Envelope {
+            schema_version: RESPONSE_SCHEMA_VERSION,
+            command: "response".to_owned(),
+            status: "error",
+            fence_version: env!("CARGO_PKG_VERSION"),
+            data: None,
+            error: Some(ErrorDetail::new(
+                "report_too_large",
+                "serialized response exceeds the fixed report limit",
+            )),
+        })
+    } else {
+        json
+    };
     CommandOutput {
-        json: serialize_envelope(&envelope),
+        json,
         exit_code,
         stderr: true,
     }
@@ -102,6 +118,22 @@ mod tests {
 
         assert_eq!(output.exit_code, 1);
         assert!(output.stderr);
+        assert!(output.json.contains("\"code\":\"report_too_large\""));
+    }
+
+    #[test]
+    fn bounds_failure_output_and_oversized_command_before_emission() {
+        let oversized = "x".repeat(MAX_REPORT_BYTES);
+        let output = failure(
+            &oversized,
+            ErrorDetail::new("invalid", "invalid").field(&oversized),
+            2,
+        );
+
+        assert_eq!(output.exit_code, 2);
+        assert!(output.stderr);
+        assert!(output.json.len() <= MAX_REPORT_BYTES);
+        assert!(output.json.contains("\"command\":\"response\""));
         assert!(output.json.contains("\"code\":\"report_too_large\""));
     }
 }


### PR DESCRIPTION
## Summary

Apply the fixed response-size limit to structured failure output as well as successful output.

## Problem

`success()` already falls back to `report_too_large` when its serialized envelope exceeds `MAX_REPORT_BYTES`, but `failure()` serialized and returned its envelope without the same bound. `failure()` and `ErrorDetail::field()` are public, so a caller can construct error context large enough to bypass the response-size guarantee. An oversized command name can also make the normal fallback oversized.

## Evidence / reproduction

- In `src/output.rs` on the base commit, `success()` serializes the envelope, compares its length with `MAX_REPORT_BYTES`, and substitutes a `report_too_large` envelope when necessary.
- The sibling public `failure()` path simply returns `serialize_envelope(&envelope)` with no size check.
- `ErrorDetail::field()` accepts caller-provided string data, and `failure()` also accepts the command string, so the failure envelope has caller-controlled fields large enough to exceed the same fixed report limit.
- Minimal reproduction on the base behavior: create a string of roughly `MAX_REPORT_BYTES`, use it as the command and as an `ErrorDetail` field, then call `failure(...)`. The returned `CommandOutput.json` can exceed `MAX_REPORT_BYTES`, while an equivalent oversized success response is bounded.
- The added regression constructs exactly that oversized failure and asserts that output remains on stderr, preserves the requested exit code, is at most `MAX_REPORT_BYTES`, and carries `report_too_large`.

The fallback uses the fixed command name `response` deliberately. Reusing the caller-provided oversized command in the fallback would recreate the same oversized-output condition.

## Change

- check serialized failure envelopes against `MAX_REPORT_BYTES`
- emit a small static `report_too_large` error envelope when the original failure response exceeds the bound
- use a bounded fallback command name so an oversized caller-provided command cannot make the fallback exceed the limit
- add a regression test covering oversized error context and command input

Existing bounded responses and exit codes are unchanged.