### PR TITLE
fix: bound resident finding evidence

### DIFF
--- a/action/finding-evidence-bounds.test.cts
+++ b/action/finding-evidence-bounds.test.cts
@@ -1,0 +1,38 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const { validateFindingEvidenceBounds } = require("./post.cts");
+
+function evidence(retained: number, sampled: number, truncated: boolean): any {
+  return {
+    findings: Array.from({ length: retained }, () => ({})),
+    findings_truncated: truncated,
+    counters: {
+      total_violations: sampled,
+      sampled_violations: sampled,
+    },
+  };
+}
+
+test("accepts resident finding evidence at producer boundaries", () => {
+  assert.equal(validateFindingEvidenceBounds(evidence(0, 0, false)).findings.length, 0);
+  assert.equal(validateFindingEvidenceBounds(evidence(1, 1, false)).findings.length, 1);
+  assert.equal(validateFindingEvidenceBounds(evidence(1024, 1024, false)).findings.length, 1024);
+  assert.equal(validateFindingEvidenceBounds(evidence(1024, 1025, true)).findings.length, 1024);
+});
+
+test("rejects resident finding evidence the producer cannot emit", () => {
+  for (const invalid of [
+    { ...evidence(0, 0, false), findings: "not-an-array" },
+    evidence(1025, 1025, false),
+    evidence(1023, 1024, true),
+    evidence(1, 2, false),
+    evidence(1024, 1024, true),
+  ]) {
+    assert.throws(
+      () => validateFindingEvidenceBounds(invalid),
+      /bounded network findings/,
+    );
+  }
+});

--- a/action/post.cts
+++ b/action/post.cts
@@ -36,6 +36,7 @@ const MANIFEST = path.join(ACTION_ROOT, "bundle-manifest.json");
 const EVIDENCE_SETTLE_INTERVAL_MILLISECONDS = 40;
 const EVIDENCE_SETTLE_MAX_READS = 4;
 const EVIDENCE_SETTLE_TIMEOUT_NANOSECONDS = 160_000_000n;
+const MAX_RETAINED_FINDINGS = 1024;
 const CHILD_ENV = {
   LANG: "C.UTF-8",
   LC_ALL: "C.UTF-8",
@@ -97,6 +98,31 @@ function networkEvidenceCounters(report: any): { total: number; sampled: number 
     total: counters.total_violations,
     sampled: counters.sampled_violations,
   };
+}
+
+function validateFindingEvidenceBounds(report: any): any {
+  const findings = report.findings;
+  const counters = networkEvidenceCounters(report);
+  if (
+    !Array.isArray(findings) ||
+    findings.length > MAX_RETAINED_FINDINGS ||
+    typeof report.findings_truncated !== "boolean" ||
+    (
+      report.findings_truncated &&
+      findings.length !== MAX_RETAINED_FINDINGS
+    ) ||
+    (
+      !report.findings_truncated &&
+      counters.sampled !== findings.length
+    ) ||
+    (
+      report.findings_truncated &&
+      counters.sampled <= findings.length
+    )
+  ) {
+    throw new Error("Fence resident report does not contain bounded network findings");
+  }
+  return report;
 }
 
 function settleResidentReport(
@@ -221,7 +247,9 @@ function main(): void {
     readJsonBounded(reportPath, MAX_REPORT_BYTES, "Fence report"),
     false,
   );
-  const report = settleResidentReport(reportPath, paths.unit, initialReport);
+  const report = validateFindingEvidenceBounds(
+    settleResidentReport(reportPath, paths.unit, initialReport),
+  );
   let dnsEvidence;
   const effectiveDnsReportPath = dnsReportPath || paths.dnsReport;
   if (fs.existsSync(effectiveDnsReportPath)) {
@@ -318,7 +346,7 @@ function main(): void {
   for (const warning of resultsStorageWarnings(dnsEvidence)) {
     log.warning(warning);
   }
-  validateReport(report, true);
+  validateFindingEvidenceBounds(validateReport(report, true));
   const auditDestinationCount = auditSummary.hostnameRows.length + auditSummary.ipRows.length;
   const evidenceLine = log.postEvidenceLine(report, auditDestinationCount);
   if (evidenceLine) {
@@ -337,4 +365,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { main, settleResidentReport };
+module.exports = { main, settleResidentReport, validateFindingEvidenceBounds };

--- a/script/test-action-wrapper
+++ b/script/test-action-wrapper
@@ -7,7 +7,7 @@ source script/env "$@"
 require_cmd node
 
 node -e 'require("./action/lib.cts"); require("./action/main.cts"); require("./action/post.cts")'
-node --test action/test.cts
+node --test action/test.cts action/finding-evidence-bounds.test.cts
 python3 -B -E script/lib/host_observation.py --self-test
 python3 -B -E script/lib/action_bundle_host.py --self-test
 script/test-action-bundle-provenance


### PR DESCRIPTION
## Summary

Make the protected post-job hook reject resident network-finding evidence that the Rust producer cannot emit.

## Problem

The Rust resident retains at most 1024 network findings. It also records a truncation flag and a lifetime sampled count with a strict relationship to the retained list.

The Action already independently validates the analogous critical-finding bound, but ordinary `findings` were only consumed or sliced downstream. A malformed report could therefore present a non-array, more than 1024 retained findings, or an impossible retained/truncated/sample-count combination without failing the protected post hook.

## Evidence / reproduction

- The Rust resident owns a bounded `FindingCollection`; the reporting path copies its retained list into `evidence.findings`, copies its truncation state into `evidence.findings_truncated`, and copies its lifetime sample count into `counters.sampled_violations`.
- The producer retains at most 1024 findings. Before that boundary, every sampled finding is retained, so `sampled_violations == findings.length`. Once the retained list is full, further samples set truncation and increase the sampled count, so valid truncated evidence has exactly 1024 retained findings and `sampled_violations > 1024`.
- On the base Action code, the protected report validator independently bounds `critical_findings`, but it has no equivalent producer-contract validation for ordinary `findings`.
- Downstream consumers even use defensive `report.findings.slice(0, 1024)` in places. That limits presentation work but does not make an impossible report invalid; extra or inconsistent evidence can be silently ignored rather than rejected.
- Minimal invalid states accepted by the old validation boundary include a non-array `findings` value, 1025 retained findings, `findings_truncated: true` with only 1023 retained rows, or a non-truncated list whose sampled count exceeds its retained length.
- `action/finding-evidence-bounds.test.cts` pins valid producer boundaries at 0, 1, 1024, and first truncation (1024 retained / 1025 sampled), then verifies those impossible combinations are rejected.

This is the same trust-boundary principle already applied to critical findings: the protected post hook should accept only evidence states the resident producer can legitimately create.

## Change

- enforce the 1024 retained-finding producer bound in the protected post hook
- require `findings_truncated` to match the producer state
- require the sampled count to equal retained findings before truncation and exceed the retained count after truncation
- validate before DNS correlation, summaries, and structured reporting
- add boundary regressions for 0, 1, 1024, first truncation, and impossible combinations

No firewall, DNS authorization, or report schema behavior changes.