### PR TITLE
docs: clarify allowlist entry limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Add destinations your workflow needs to the `allowlist`:
       cidr 192.0.2.0/24 udp 123
 ```
 
-Bare hostnames default to TCP port `443`. Fence also supports IPv6, custom ports, TCP, UDP, CIDR ranges, and one- or two-level hostname wildcards. An allowlist can contain up to 64 unique entries.
+Bare hostnames default to TCP port `443`. Fence also supports IPv6, custom ports, TCP, UDP, CIDR ranges, and one- or two-level hostname wildcards. The multiline `allowlist` input can contain up to 64 unique normalized entries; the advanced JSON `config` input accepts at most 64 array entries before deduplication.
 
 See [allowlist syntax](docs/allowlist.md) for all supported formats.
 

--- a/docs/allowlist.md
+++ b/docs/allowlist.md
@@ -46,12 +46,12 @@ A hostname without a port uses TCP port `443`. Use the explicit `ip` or `cidr` f
 
 ## Entry Limit
 
-An allowlist can contain up to 64 unique entries. Fence normalizes hostnames and IP addresses before counting, so duplicates, capitalization differences, and equivalent address formats count only once. Different ports, protocols, and destination types count separately.
+The native multiline `allowlist` input can contain up to 64 unique normalized entries. Fence normalizes hostnames and IP addresses before counting that input, so duplicates, capitalization differences, and equivalent address formats count only once. Different ports, protocols, and destination types count separately.
 
-The 65th unique entry fails before Fence changes the runner.
+The 65th unique native entry fails before Fence changes the runner.
 
 > [!NOTE]
-> The advanced JSON `config` input also has a 64-entry limit. It cannot be combined with native Action inputs.
+> The advanced JSON `config` input uses a stricter physical-entry boundary: its `allowlist` array may contain at most 64 entries before normalization and deduplication. Repeating the same JSON allowance still consumes an array entry. Advanced `config` cannot be combined with native Action inputs.
 
 ## Wildcards
 


### PR DESCRIPTION
## Summary

Clarify that Fence has different 64-entry counting semantics for the native multiline Action input and the advanced JSON configuration.

## Problem

The public docs currently say an allowlist may contain 64 unique entries and that duplicates count only once, then describe the advanced JSON `config` input as having the same 64-entry limit.

That is accurate for the native multiline input, which normalizes and deduplicates before enforcing its unique-entry limit. The advanced JSON path intentionally rejects an `allowlist` array with more than 64 physical entries before normalization, so duplicate JSON entries still consume the limit.

## Evidence / reproduction

- In `action/lib.cts`, the native multiline parser canonicalizes each allowance, tracks it in a `Set`, and enforces the limit only when a new unique canonical entry would be added. Repeated or equivalent native lines therefore do not consume additional slots.
- The advanced JSON path first requires `parsed.allowlist.length <= 64`. That check is on the physical array length, before allowance normalization/deduplication.
- Existing `action/test.cts` coverage reflects both contracts: the native-input tests verify canonical duplicates count once, while the raw JSON configuration test verifies a 65-element array is rejected.
- Minimal reproduction: provide the same valid destination 65 times through native multiline `allowlist`; it normalizes to one entry. Put the same allowance object 65 times in advanced JSON `config`; validation rejects the array for exceeding 64 entries.
- The previous wording in `docs/allowlist.md` says duplicates count only once and immediately notes that advanced JSON also has a 64-entry limit, which naturally implies the same counting semantics even though the implementation and tests say otherwise.

This PR changes only the documentation so each public input describes the limit it already enforces.

## Change

- identify the 64-unique-entry rule as the native multiline input behavior
- document that advanced JSON accepts at most 64 physical array entries before deduplication
- keep the README summary consistent with the detailed allowlist guide

Documentation only; no input-validation or policy behavior changes.