### PR TITLE
docs: document render-plan DNS resolution

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -31,7 +31,7 @@ This shows the operating system, architecture, available backend, and reference 
 fence render-plan --config policy.json
 ```
 
-This validates a JSON configuration and prints the firewall rules without applying them.
+This validates a JSON configuration and prints the firewall rules without applying them. Exact hostname allowlist entries are resolved through the system resolver while the plan is built, so a preview that contains hostnames can perform DNS lookups and can fail if resolution is unavailable.
 
 ## Run The Agent
 


### PR DESCRIPTION
## Summary

Document that `fence render-plan` can perform DNS lookups when the policy contains exact hostname allowlist entries.

## Problem

The CLI reference currently says `render-plan` validates JSON and prints firewall rules without applying them. That correctly describes host mutation, but it omits a separate observable side effect: the planner resolves exact hostname entries while building the frozen plan.

A user can therefore run a preview expecting a purely local operation and still generate DNS traffic or receive a DNS-resolution failure.

## Evidence / reproduction

- `src/cli.rs::render_plan` calls `build_plan(normalized, resolver)`, and the system CLI supplies `SystemResolver`.
- The plan builder resolves exact hostname allowances before rendering their effective IP allowances; this is how the preview freezes hostname policy into concrete addresses.
- Existing CLI tests already exercise the failure path: a resolver failure while previewing a hostname policy produces `dns_resolution_failed`.
- Minimal reproduction on a normal host: use a `render-plan` config containing an exact hostname and make system DNS unavailable. The command fails during planning even though it never applies nftables state.
- IP- and CIDR-only preview policies do not require this hostname-resolution step.

The distinction matters for offline or tightly controlled development environments: `render-plan` is non-mutating with respect to Fence enforcement, but hostname-based previews are not necessarily network-free.

## Change

Add one sentence to the CLI reference stating that exact hostname entries are resolved through the system resolver during planning and that DNS failure can fail the preview.

Documentation only; no planner, resolver, or firewall behavior changes.