### PR TITLE
fix: validate all direct Cargo dependency pins

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -6,9 +6,11 @@ source script/env "$@"
 
 ensure_rust_toolchain
 require_cmd cargo
+require_cmd python3
 
 echo -e "Rust version: ${GREEN}${RUST_VERSION}${OFF}"
 
+python3 -B -E "$DIR/script/lib/cargo_dependency_pins.py" "$DIR/Cargo.toml"
 ensure_vendor_cache
 
 # This validates that the deps are available so the project can be built offline.

--- a/script/lib/cargo_dependency_pins.py
+++ b/script/lib/cargo_dependency_pins.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+
+import pathlib
+import sys
+import tomllib
+import unittest
+
+DEPENDENCY_KINDS = ("dependencies", "dev-dependencies", "build-dependencies")
+
+
+def dependency_tables(document):
+    for kind in DEPENDENCY_KINDS:
+        table = document.get(kind)
+        if table is not None:
+            yield f"[{kind}]", table
+
+    targets = document.get("target", {})
+    if not isinstance(targets, dict):
+        raise ValueError("Cargo.toml target configuration must be a table")
+    for selector, target in targets.items():
+        if not isinstance(target, dict):
+            raise ValueError(f"Cargo.toml target {selector!r} must be a table")
+        for kind in DEPENDENCY_KINDS:
+            table = target.get(kind)
+            if table is not None:
+                yield f"[target.{selector!r}.{kind}]", table
+
+
+def exact_version(specification):
+    if isinstance(specification, str):
+        version = specification
+    elif isinstance(specification, dict):
+        version = specification.get("version")
+    else:
+        return False
+    return isinstance(version, str) and version.startswith("=") and len(version) > 1
+
+
+def validate_document(document):
+    if not isinstance(document, dict):
+        raise ValueError("Cargo.toml root must be a table")
+
+    violations = []
+    for location, table in dependency_tables(document):
+        if not isinstance(table, dict):
+            raise ValueError(f"Cargo.toml dependency section {location} must be a table")
+        for name, specification in sorted(table.items()):
+            if not exact_version(specification):
+                violations.append(f"{location} {name}")
+    return violations
+
+
+def validate_path(path):
+    with path.open("rb") as handle:
+        document = tomllib.load(handle)
+    violations = validate_document(document)
+    if violations:
+        joined = ", ".join(violations)
+        raise ValueError(f"direct Cargo dependencies must use exact versions: {joined}")
+
+
+class CargoDependencyPinTests(unittest.TestCase):
+    def parse(self, raw):
+        return tomllib.loads(raw)
+
+    def test_accepts_exact_versions_in_every_direct_dependency_table(self):
+        document = self.parse(
+            '''
+[dependencies]
+serde = "=1.0.228"
+
+[dev-dependencies]
+tempfile = { version = "=3.23.0", features = ["nightly"] }
+
+[build-dependencies]
+cc = "=1.2.43"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = "=0.2.186"
+netlink-sys = { version = "=0.8.8", features = ["tokio_socket"] }
+
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+nix = "=0.30.1"
+
+[target.'cfg(target_os = "linux")'.build-dependencies]
+bindgen = { version = "=0.72.1" }
+'''
+        )
+        self.assertEqual(validate_document(document), [])
+
+    def test_rejects_non_exact_versions_outside_plain_dependencies(self):
+        cases = (
+            (
+                '''
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = "0.2.186"
+''',
+                "libc",
+            ),
+            (
+                '''
+[dev-dependencies]
+tempfile = { version = "3.23.0" }
+''',
+                "tempfile",
+            ),
+            (
+                '''
+[build-dependencies]
+cc = { path = "vendor/cc" }
+''',
+                "cc",
+            ),
+        )
+        for raw, dependency in cases:
+            with self.subTest(dependency=dependency):
+                violations = validate_document(self.parse(raw))
+                self.assertEqual(len(violations), 1)
+                self.assertIn(dependency, violations[0])
+
+
+if __name__ == "__main__":
+    if sys.argv[1:] == ["--self-test"]:
+        unittest.main(argv=[sys.argv[0]])
+    elif len(sys.argv) == 2:
+        try:
+            validate_path(pathlib.Path(sys.argv[1]))
+        except (OSError, tomllib.TOMLDecodeError, ValueError) as error:
+            raise SystemExit(str(error)) from None
+    else:
+        raise SystemExit("usage: cargo_dependency_pins.py <Cargo.toml> | --self-test")

--- a/script/lint
+++ b/script/lint
@@ -27,6 +27,8 @@ if [[ $# -gt 1 ]]; then
   exit 2
 fi
 
+python3 -B -E "$DIR/script/lib/cargo_dependency_pins.py" --self-test
+
 if [[ "$CHECK_FORMAT" == "true" ]]; then
   cargo fmt --all -- --check
 else


### PR DESCRIPTION
## Summary

Enforce Fence's exact-version policy across every direct Cargo dependency table, including target-specific, dev, and build dependencies.

## Problem

Fence's repository policy requires all direct dependencies in `Cargo.toml` to use exact versions. The current `script/validate-locks` checker enters `[dependencies]` and exits at the next table header, so its exact-version check never inspects other direct dependency tables.

That leaves target-specific, `[dev-dependencies]`, `[build-dependencies]`, and their target-specific forms outside the stated pinning guardrail.

## Evidence / reproduction

- `AGENTS.md` states that all direct Cargo dependencies in `Cargo.toml` must use exact versions such as `=1.2.3`.
- The existing `validate_direct_dependencies_exact` awk scanner starts only on the exact `[dependencies]` header and exits when the next TOML table begins.
- The current manifest already demonstrates the gap structurally: `libc` and `netlink-sys` live under `[target.'cfg(target_os = "linux")'.dependencies]`, after the ordinary dependencies table has ended.
- Minimal reproduction on the base validator: change target-specific `libc = "=0.2.186"` to `libc = "0.2.186"`. The ordinary direct-dependency exactness scanner does not inspect that table, so this specific guard does not detect the relaxed pin.
- `deny.toml` rejects wildcard dependency requirements, but that is a different constraint and does not require the exact `=` operator.
- The new self-tests cover exact versions in ordinary, dev, build, target-specific dependency, target-specific dev, and target-specific build tables, then verify relaxed or missing versions in the previously uncovered tables are rejected.

The validator uses Python's TOML parser rather than extending line-oriented matching, so inline-table dependency declarations and target selector quoting are interpreted as TOML structure rather than shell text.

## Change

- add a small TOML-aware validator for all direct Cargo dependency tables
- run the actual manifest validation during `script/bootstrap`, which is used by the protected CI workflows before Cargo work
- run focused validator self-tests from `script/lint`
- preserve the existing exact pins and Cargo lock/vendor checks

No dependency versions or runtime behavior change.