### PR TITLE
fix: validate retained test-tool identities

### DIFF
--- a/script/validate-test-tools
+++ b/script/validate-test-tools
@@ -38,6 +38,7 @@ if ! diff -u <(test_tools_cargo_llvm_cov_license_entries "$lockfile" | sort) <(t
 fi
 
 artifact_count=0
+artifact_platforms="|"
 while IFS='|' read -r platform arch os target version url path sha256; do
   artifact_count=$((artifact_count + 1))
   if [[ -z "$platform" || -z "$arch" || -z "$os" || -z "$target" || -z "$version" || -z "$url" || -z "$path" || -z "$sha256" ]]; then
@@ -45,6 +46,25 @@ while IFS='|' read -r platform arch os target version url path sha256; do
   fi
   if [[ "$version" != "$cargo_llvm_cov_version" ]]; then
     die "cargo-llvm-cov entry version mismatch for ${platform}"
+  fi
+  case "${platform}|${arch}|${os}|${target}" in
+    "linux-x86_64|x86_64|linux|x86_64-unknown-linux-gnu"|\
+    "linux-aarch64|aarch64|linux|aarch64-unknown-linux-gnu"|\
+    "macos-x86_64|x86_64|macos|x86_64-apple-darwin"|\
+    "macos-aarch64|aarch64|macos|aarch64-apple-darwin") ;;
+    *) die "unexpected cargo-llvm-cov platform identity: ${platform}|${arch}|${os}|${target}" ;;
+  esac
+  if [[ "$artifact_platforms" == *"|${platform}|"* ]]; then
+    die "duplicate cargo-llvm-cov platform entry: ${platform}"
+  fi
+  artifact_platforms+="${platform}|"
+  expected_url="https://github.com/taiki-e/cargo-llvm-cov/releases/download/v${version}/cargo-llvm-cov-${target}.tar.gz"
+  expected_path="vendor/test-tools/cargo-llvm-cov/cargo-llvm-cov-${target}.tar.gz"
+  if [[ "$url" != "$expected_url" ]]; then
+    die "cargo-llvm-cov artifact URL mismatch for ${platform}"
+  fi
+  if [[ "$path" != "$expected_path" ]]; then
+    die "cargo-llvm-cov artifact path mismatch for ${platform}"
   fi
   reject_unsafe_relative_path "$path" "cargo-llvm-cov manifest path for ${platform}"
   artifact="$DIR/$path"
@@ -78,6 +98,10 @@ while IFS='|' read -r name version url path sha256; do
   esac
   if [[ "$version" != "$cargo_llvm_cov_version" ]]; then
     die "cargo-llvm-cov license version mismatch for $name"
+  fi
+  expected_url="https://raw.githubusercontent.com/taiki-e/cargo-llvm-cov/v${version}/${name}"
+  if [[ "$url" != "$expected_url" ]]; then
+    die "cargo-llvm-cov license URL mismatch for $name"
   fi
   if [[ "$path" != "vendor/test-tools/cargo-llvm-cov/$name" ]]; then
     die "cargo-llvm-cov license has unexpected path: $path"


### PR DESCRIPTION
## Summary

Make the retained `cargo-llvm-cov` validator require the exact supported platform matrix and official source identities, rather than accepting any four checksum-valid records.

## Problem

`script/validate-test-tools` compares the committed lockfile and generated manifest, validates versions and checksums, and requires exactly four retained `cargo-llvm-cov` artifacts. On the base commit, however, it does not verify that those four records are the intended four platform/architecture/target tuples, and it does not bind their recorded URLs to the official release locations.

Because the lockfile and generated manifest are checked against each other, the same malformed or relabelled record can appear in both and still satisfy that equality check. Counting four records is not equivalent to proving the four supported host artifacts are represented exactly once.

## Evidence / reproduction

- The intended matrix in the current lock is:
  - `linux-x86_64 | x86_64 | linux | x86_64-unknown-linux-gnu`
  - `linux-aarch64 | aarch64 | linux | aarch64-unknown-linux-gnu`
  - `macos-x86_64 | x86_64 | macos | x86_64-apple-darwin`
  - `macos-aarch64 | aarch64 | macos | aarch64-apple-darwin`
- `script/validate-test-tools` currently checks only that each artifact record is non-empty, has the expected version, points to a safe relative path, hashes to the recorded digest, contains the executable, and that the total count is four.
- `script/install-test-tools` later selects the retained artifact by the runtime `platform` and `target`, so these identity fields are operationally significant.
- Minimal structural reproduction on the base validator: duplicate one valid platform record and remove another, update both the lock and generated manifest consistently, and keep four valid retained archives/digests. The count and lock/manifest equality checks do not independently reject the missing platform identity.
- Similarly, the base validator does not derive the expected artifact URL or licence URL from the reviewed tool/version identity; a lock and manifest that agree on another URL can pass the source-field checks as long as the retained bytes match the recorded digest.

## Change

- require exactly the four reviewed `platform | arch | os | target` tuples
- reject duplicate platform records
- derive and require the official `cargo-llvm-cov` release URL for each target
- derive and require the corresponding vendored archive path
- derive and require the official upstream URLs for the Apache and MIT licence records
- preserve all existing checksum, archive, offline-install and licence-content validation

No retained artifact bytes, versions, or installation behavior change.