### PR TITLE
fix: validate retained release-tool identities

### DIFF
--- a/script/validate-release-tools
+++ b/script/validate-release-tools
@@ -45,6 +45,7 @@ if ! diff -u <(release_tools_zig_entries "$lockfile" | sort) <(release_tools_zig
 fi
 
 zig_count=0
+zig_platforms="|"
 while IFS='|' read -r platform arch os version url path sha256; do
   zig_count=$((zig_count + 1))
   if [[ -z "$platform" || -z "$arch" || -z "$os" || -z "$version" || -z "$url" || -z "$path" || -z "$sha256" ]]; then
@@ -52,6 +53,25 @@ while IFS='|' read -r platform arch os version url path sha256; do
   fi
   if [[ "$version" != "$zig_version" ]]; then
     die "Zig entry version mismatch for ${platform}"
+  fi
+  case "${platform}|${arch}|${os}" in
+    "macos-x86_64|x86_64|macos"|\
+    "macos-aarch64|aarch64|macos"|\
+    "linux-x86_64|x86_64|linux"|\
+    "linux-aarch64|aarch64|linux") ;;
+    *) die "unexpected Zig platform identity: ${platform}|${arch}|${os}" ;;
+  esac
+  if [[ "$zig_platforms" == *"|${platform}|"* ]]; then
+    die "duplicate Zig platform entry: ${platform}"
+  fi
+  zig_platforms+="${platform}|"
+  expected_zig_url="https://ziglang.org/download/${version}/zig-${arch}-${os}-${version}.tar.xz"
+  expected_zig_path="vendor/release-tools/zig/zig-${arch}-${os}-${version}.tar.xz"
+  if [[ "$url" != "$expected_zig_url" ]]; then
+    die "Zig artifact URL mismatch for ${platform}"
+  fi
+  if [[ "$path" != "$expected_zig_path" ]]; then
+    die "Zig artifact path mismatch for ${platform}"
   fi
   reject_unsafe_relative_path "$path" "Zig manifest path for ${platform}"
   artifact="$DIR/$path"
@@ -80,6 +100,14 @@ if [[ -z "$lock_cargo_entry_version" || -z "$lock_cargo_entry_url" || -z "$lock_
 fi
 if [[ "$lock_cargo_entry_version" != "$cargo_zigbuild_version" ]]; then
   die "${RELEASE_TOOLS_LOCK#$DIR/} cargo-zigbuild entry version mismatch (expected ${cargo_zigbuild_version}, found ${lock_cargo_entry_version})"
+fi
+expected_cargo_entry_url="https://static.crates.io/crates/cargo-zigbuild/cargo-zigbuild-${cargo_zigbuild_version}.crate"
+expected_cargo_entry_path="vendor/release-tools/cargo-zigbuild/cargo-zigbuild-${cargo_zigbuild_version}.crate"
+if [[ "$lock_cargo_entry_url" != "$expected_cargo_entry_url" ]]; then
+  die "${RELEASE_TOOLS_LOCK#$DIR/} cargo-zigbuild crate URL mismatch"
+fi
+if [[ "$lock_cargo_entry_path" != "$expected_cargo_entry_path" ]]; then
+  die "${RELEASE_TOOLS_LOCK#$DIR/} cargo-zigbuild crate path mismatch"
 fi
 reject_unsafe_relative_path "$lock_cargo_entry_path" "${RELEASE_TOOLS_LOCK#$DIR/} cargo-zigbuild crate path"
 


### PR DESCRIPTION
## Summary

Bind the retained Zig and `cargo-zigbuild` inventory to the exact reviewed platform and upstream source identities, instead of validating only count/version/checksum consistency.

## Problem

`script/validate-release-tools` compares the human-reviewed lockfile with the generated retained-artifact manifest, verifies artifact hashes, and requires four Zig records. On the base commit it does not independently verify that those four records are the intended four platform/architecture/OS combinations, nor that their recorded URLs and vendored paths correspond to the official Zig release locations.

The `cargo-zigbuild` record is similarly checked for version and lock/manifest equality, but its upstream crate URL and exact retained crate path are not derived and enforced by the validator.

Lock/manifest equality protects against accidental divergence between those two files, but it does not establish that an agreed pair still describes the reviewed source identity.

## Evidence / reproduction

- The current reviewed Zig matrix is exactly:
  - `macos-x86_64 | x86_64 | macos`
  - `macos-aarch64 | aarch64 | macos`
  - `linux-x86_64 | x86_64 | linux`
  - `linux-aarch64 | aarch64 | linux`
- The base validator requires four non-empty Zig records, the current Zig version, safe relative paths, matching retained SHA-256s, and valid tar entries, but it does not reject duplicate/missing platform identities when the lock and manifest agree.
- `script/install-zig` selects an artifact by the runtime platform, so the recorded platform identities are operationally significant.
- `script/vendor-release-tools` treats `.cargo/tooling/release-tools.lock.toml` as the download source and fetches the URL stored in each Zig record. The current base validator does not require that URL to be `https://ziglang.org/download/<version>/zig-<arch>-<os>-<version>.tar.xz`.
- The reviewed `cargo-zigbuild` input currently comes from `https://static.crates.io/crates/cargo-zigbuild/cargo-zigbuild-<version>.crate`, but the base validator only compares the stored URL between lock and manifest rather than deriving that expected source.
- Minimal structural reproduction on the base validator: consistently alter a Zig platform label/source URL in both lock and generated manifest while retaining a checksum-valid archive, or replace one supported platform record with a duplicate and keep the count at four. The existing count/equality/hash checks do not independently enforce the intended platform/source identity.

## Change

- require the exact four reviewed Zig `platform | arch | os` tuples
- reject duplicate Zig platform entries
- derive and require each official Zig release URL and vendored archive path
- derive and require the exact crates.io `cargo-zigbuild` crate URL and retained crate path
- preserve all existing lock/manifest equality, checksum, archive and offline-install validation

No retained tool versions, artifact bytes, release workflow behavior, or runtime behavior change.