### PR TITLE
fix: reject generated directory symlinks

### DIFF
--- a/script/lib/common.bash
+++ b/script/lib/common.bash
@@ -124,11 +124,30 @@ require_generated_path() {
   fi
 }
 
+require_no_generated_symlink_components() {
+  local path="$1"
+  local description="$2"
+  local include_path="$3"
+  local candidate="$path"
+
+  if [[ "$include_path" != "true" ]]; then
+    candidate="${candidate%/*}"
+  fi
+  while [[ -n "$candidate" && "$candidate" != "/" && "$candidate" != "$DIR" && "$candidate" != "${RUNNER_TEMP:-__unset__}" && "$candidate" != "${TMPDIR:-__unset__}" ]]; do
+    if [[ -L "$candidate" ]]; then
+      die "${description} must not traverse a symbolic link: $candidate"
+    fi
+    candidate="${candidate%/*}"
+    [[ -n "$candidate" ]] || candidate="/"
+  done
+}
+
 remove_generated_path() {
   local path="$1"
   local description="$2"
 
   require_generated_path "$path" "$description"
+  require_no_generated_symlink_components "$path" "$description" false
   rm -rf "$path"
 }
 
@@ -137,9 +156,7 @@ clear_generated_dir() {
   local description="$2"
 
   require_generated_path "$path" "$description"
-  if [[ -L "$path" ]]; then
-    die "${description} must not be a symbolic link: $path"
-  fi
+  require_no_generated_symlink_components "$path" "$description" true
   mkdir -p "$path"
   find "$path" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
 }

--- a/script/lib/common.bash
+++ b/script/lib/common.bash
@@ -137,6 +137,9 @@ clear_generated_dir() {
   local description="$2"
 
   require_generated_path "$path" "$description"
+  if [[ -L "$path" ]]; then
+    die "${description} must not be a symbolic link: $path"
+  fi
   mkdir -p "$path"
   find "$path" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
 }

--- a/script/test
+++ b/script/test
@@ -22,6 +22,8 @@ case "${1:-}" in
     ;;
 esac
 
+bash script/test-generated-paths
+
 if [[ -z "${1:-}" ]]; then
   cargo test --frozen
   exit 0

--- a/script/test-generated-paths
+++ b/script/test-generated-paths
@@ -17,20 +17,42 @@ cleanup() {
 trap cleanup EXIT
 
 mkdir -p "$tmp_root/outside" "$DIR/target"
+printf '%s\n' "outside" > "$tmp_root/outside/victim"
 ln -s "$tmp_root/outside" "$link"
 
 output=""
 if output="$(clear_generated_dir "$link" "generated-path regression directory" 2>&1)"; then
   die "clear_generated_dir unexpectedly accepted a symbolic-link directory"
 fi
-if ! grep -Fq "must not be a symbolic link" <<< "$output"; then
+if ! grep -Fq "must not traverse a symbolic link" <<< "$output"; then
   die "clear_generated_dir did not report the symbolic-link failure"
 fi
-if [[ ! -L "$link" ]]; then
-  die "generated-path regression changed the symbolic-link path"
+
+output=""
+if output="$(clear_generated_dir "$link/nested" "generated-path nested regression directory" 2>&1)"; then
+  die "clear_generated_dir unexpectedly traversed a symbolic-link ancestor"
 fi
-if find "$tmp_root/outside" -mindepth 1 -print -quit | grep -q .; then
-  die "generated-path regression modified the symlink target"
+if ! grep -Fq "must not traverse a symbolic link" <<< "$output"; then
+  die "clear_generated_dir did not report the symbolic-link ancestor failure"
+fi
+
+output=""
+if output="$(remove_generated_path "$link/victim" "generated-path nested removal" 2>&1)"; then
+  die "remove_generated_path unexpectedly traversed a symbolic-link ancestor"
+fi
+if ! grep -Fq "must not traverse a symbolic link" <<< "$output"; then
+  die "remove_generated_path did not report the symbolic-link ancestor failure"
+fi
+if [[ "$(cat "$tmp_root/outside/victim")" != "outside" ]]; then
+  die "generated-path regression modified a file through a symbolic-link ancestor"
+fi
+
+remove_generated_path "$link" "generated-path regression link"
+if [[ -e "$link" || -L "$link" ]]; then
+  die "remove_generated_path did not remove the final symbolic link"
+fi
+if [[ ! -f "$tmp_root/outside/victim" ]]; then
+  die "removing the final symbolic link changed its target"
 fi
 
 echo -e "${GREEN}generated path symlink regression passed${OFF}"

--- a/script/test-generated-paths
+++ b/script/test-generated-paths
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source script/env "$@"
+
+if [[ $# -ne 0 ]]; then
+  die "usage: script/test-generated-paths"
+fi
+
+tmp_root="$(make_temp_dir fence-generated-paths "$RUNNER_TEMP")"
+link="$DIR/target/generated-path-symlink-$$"
+cleanup() {
+  remove_generated_path "$link" "generated-path regression link" 2>/dev/null || true
+  remove_generated_path "$tmp_root" "generated-path regression root" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+mkdir -p "$tmp_root/outside" "$DIR/target"
+ln -s "$tmp_root/outside" "$link"
+
+output=""
+if output="$(clear_generated_dir "$link" "generated-path regression directory" 2>&1)"; then
+  die "clear_generated_dir unexpectedly accepted a symbolic-link directory"
+fi
+if ! grep -Fq "must not be a symbolic link" <<< "$output"; then
+  die "clear_generated_dir did not report the symbolic-link failure"
+fi
+if [[ ! -L "$link" ]]; then
+  die "generated-path regression changed the symbolic-link path"
+fi
+if find "$tmp_root/outside" -mindepth 1 -print -quit | grep -q .; then
+  die "generated-path regression modified the symlink target"
+fi
+
+echo -e "${GREEN}generated path symlink regression passed${OFF}"


### PR DESCRIPTION
## Summary

Make Fence's generated-path helpers fail closed instead of traversing symbolic-link components below their approved generated roots.

## Problem

Fence restricts generated-directory management to reviewed repo-generated paths, `RUNNER_TEMP`, or `TMPDIR`, but the base helper validates only the literal path string. A path can therefore satisfy the approved prefix check while one of its filesystem components is a symlink to a different location.

For `clear_generated_dir`, this is especially subtle. If the final managed path is itself a symlink, GNU `find` does not follow that command-line symlink in the current invocation, so the clear can return successfully. Later writes such as `cp "$binary" "$dist_dir/$name"` or coverage output creation then follow the symlink and land outside the approved generated root. The same escape is possible when an intermediate component is a symlink.

`remove_generated_path` has a related intermediate-component case: removing a final symlink is safe because `rm -rf` removes the link itself, but a path such as `<symlink-parent>/child` traverses the parent symlink before `rm` reaches the child.

## Evidence / reproduction

- `script/lib/common.bash::require_generated_path` checks the literal path against approved prefixes but does not inspect filesystem components.
- `script/build` calls `clear_generated_dir` for its distribution directory before copying release artifacts into that path.
- `script/test --coverage` calls the same helper before writing coverage outputs.
- Minimal final-link reproduction on the base helper: create an approved path such as `$DIR/target/generated-link` as a symlink to another directory, call `clear_generated_dir` on it, then write `generated-link/file`. The clear can return without clearing the target, while the subsequent write lands in the symlink target.
- Minimal ancestor reproduction: use `$DIR/target/generated-link/nested` as the managed path. The literal path remains under `$DIR/target`, but filesystem resolution crosses `generated-link` before reaching `nested`.
- The same ancestor shape matters for removal: `remove_generated_path "$link/victim"` can otherwise address a file in the symlink target, even though `remove_generated_path "$link"` itself is safe.
- `script/test-generated-paths` now covers all three boundaries: final-link clearing is rejected, intermediate-link clearing/removal is rejected, and deleting the final symlink itself remains permitted while its target remains untouched.

## Change

- add one shared check for symbolic-link components below the trusted generated root
- make `clear_generated_dir` reject both final and intermediate symlink components
- make `remove_generated_path` reject symlink ancestors while still allowing safe removal of the final symlink itself
- add focused regressions and run them from the normal offline `script/test` entrypoint

No normal generated-directory layout, artifact location, or cleanup behavior changes for ordinary non-symlink paths.