### PR TITLE
fix: refuse Cargo config backup collisions

### DIFF
--- a/script/test
+++ b/script/test
@@ -11,6 +11,7 @@ script/validate-test-tools
 script/test-action-release
 python3 -B -E "$DIR/script/lib/protected_finalization.py" --self-test
 script/test-rust-toolchain-preparation
+bash script/test-update-backup-safety
 
 case "${1:-}" in
   "" )

--- a/script/test-update-backup-safety
+++ b/script/test-update-backup-safety
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source script/env "$@"
+
+if [[ $# -ne 0 ]]; then
+  die "usage: script/test-update-backup-safety"
+fi
+
+config="$DIR/.cargo/config.toml"
+backup="$DIR/.cargo/config.toml.bak"
+
+if [[ ! -f "$config" ]]; then
+  die "missing .cargo/config.toml test fixture"
+fi
+if [[ -e "$backup" || -L "$backup" ]]; then
+  die "Cargo config backup path must be absent before the regression"
+fi
+
+config_sha256="$(sha256_file "$config")"
+mkdir "$backup"
+cleanup() {
+  if [[ -d "$backup" ]]; then
+    rmdir "$backup"
+  fi
+}
+trap cleanup EXIT
+
+output=""
+if output="$(script/update 2>&1)"; then
+  die "script/update unexpectedly accepted an existing backup directory"
+fi
+if ! grep -Fq "refusing to overwrite existing backup" <<< "$output"; then
+  die "script/update did not report the backup collision"
+fi
+if [[ ! -f "$config" || "$(sha256_file "$config")" != "$config_sha256" ]]; then
+  die "script/update changed .cargo/config.toml after a backup collision"
+fi
+if [[ ! -d "$backup" ]] || find "$backup" -mindepth 1 -print -quit | grep -q .; then
+  die "script/update changed the pre-existing backup directory"
+fi
+
+echo -e "${GREEN}update backup collision regression passed${OFF}"

--- a/script/update
+++ b/script/update
@@ -7,13 +7,6 @@ source "$DIR/script/lib/update-tools.bash"
 
 ensure_rust_toolchain
 
-unset CARGO_NET_OFFLINE
-
-echo -e "Rust version: ${GREEN}${RUST_VERSION}${OFF}"
-script/validate-update-tools --ci
-require_cmd curl
-require_cmd tar
-
 config="$DIR/.cargo/config.toml"
 backup="$DIR/.cargo/config.toml.bak"
 
@@ -21,12 +14,19 @@ if [[ ! -f "$config" ]]; then
   die "missing .cargo/config.toml"
 fi
 
-if [[ -f "$backup" ]]; then
+if [[ -e "$backup" || -L "$backup" ]]; then
   die "refusing to overwrite existing backup: $backup"
 fi
 
+unset CARGO_NET_OFFLINE
+
+echo -e "Rust version: ${GREEN}${RUST_VERSION}${OFF}"
+script/validate-update-tools --ci
+require_cmd curl
+require_cmd tar
+
 restore_config() {
-  if [[ -f "$backup" ]]; then
+  if [[ -e "$backup" || -L "$backup" ]]; then
     mv "$backup" "$config"
   fi
 }
@@ -41,8 +41,8 @@ cleanup() {
 
 # Temporarily move the offline Cargo config aside so the update path can reach
 # crates.io. This is the only script that should do this.
-mv "$config" "$backup"
 trap cleanup EXIT
+mv "$config" "$backup"
 
 cargo update
 if [[ -z "$VENDOR_DIR" || "$VENDOR_DIR" == "/" ]]; then


### PR DESCRIPTION
## Summary

Fail `script/update` before any online work when `.cargo/config.toml.bak` already exists in any filesystem form, instead of checking only for a regular file.

## Problem

The update path temporarily moves `.cargo/config.toml` to `.cargo/config.toml.bak` so Cargo can reach crates.io without the repository's offline replacement configuration. On the base commit, the collision guard is:

```bash
if [[ -f "$backup" ]]; then
  die ...
fi
```

That detects an existing regular file (and a symlink resolving to one), but not an existing directory. `mv "$config" "$backup"` treats an existing directory as a destination directory and moves the config to `.cargo/config.toml.bak/config.toml`. The cleanup helper then checks `[[ -f "$backup" ]]`, which is false for the directory, so it does not restore `.cargo/config.toml`.

A failed update can therefore leave the repository's Cargo configuration displaced simply because the reserved backup path was a directory.

## Evidence / reproduction

- `script/update` uses the fixed backup path `$DIR/.cargo/config.toml.bak`.
- The base preflight rejects that path only when `[[ -f "$backup" ]]` is true.
- POSIX/GNU `mv source existing-directory` moves `source` *into* that directory rather than replacing the directory.
- The base `restore_config` uses the same `[[ -f "$backup" ]]` test, so once the config has been moved inside the directory, the backup path itself still fails the regular-file predicate and no restoration occurs.
- Minimal reproduction on the base control flow: create an empty `.cargo/config.toml.bak/` directory before invoking the update script. The collision guard does not fire, and the subsequent move targets that directory.
- The new offline regression creates exactly that collision, invokes `script/update`, requires the explicit early failure, and verifies both that `.cargo/config.toml` retains its original SHA-256 and that the pre-existing directory remains empty.

The collision check is deliberately moved before `unset CARGO_NET_OFFLINE` and `script/validate-update-tools --ci`, so this local filesystem error is rejected before the update path performs network preparation.

## Change

- reject any existing backup path using `-e` plus `-L`, covering directories and dangling symlinks as well as regular files
- perform that preflight before enabling the online update phase
- install cleanup before moving the Cargo config so an exit after the move can restore it
- make restoration recognize any existing reserved backup path created by the successful move
- add an offline regression and run it from the normal `script/test` entrypoint

No dependency versions, lockfiles, vendor contents, or normal successful update behavior change.