### PR TITLE
fix: validate Rust toolchain lock surface

### DIFF
--- a/script/validate-rust-lock-surface
+++ b/script/validate-rust-lock-surface
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+
+import pathlib
+import sys
+import tempfile
+import tomllib
+
+
+def parse_csv(value: str) -> list[str]:
+    return [item for item in value.split(",") if item]
+
+
+def validate(path: pathlib.Path, hosts: list[str], targets: list[str], components: list[str]) -> None:
+    with path.open("rb") as source:
+        document = tomllib.load(source)
+    rust = document.get("rust")
+    if not isinstance(rust, dict):
+        raise ValueError("Rust toolchain lock is missing its rust table")
+    expected = {
+        "hosts": hosts,
+        "targets": targets,
+        "host_components": components,
+    }
+    for field, value in expected.items():
+        if rust.get(field) != value:
+            raise ValueError(f"Rust toolchain lock {field} declaration does not match the reviewed surface")
+
+
+def self_test() -> None:
+    hosts = ["host-a", "host-b"]
+    targets = ["target-a", "target-b"]
+    components = ["rustc", "cargo"]
+    with tempfile.TemporaryDirectory(prefix="fence-rust-lock-surface-") as temporary:
+        path = pathlib.Path(temporary) / "lock.toml"
+        path.write_text(
+            "[rust]\n"
+            'hosts = ["host-a", "host-b"]\n'
+            'targets = ["target-a", "target-b"]\n'
+            'host_components = ["rustc", "cargo"]\n',
+            encoding="utf-8",
+        )
+        validate(path, hosts, targets, components)
+
+        for field, replacement in (
+            ("hosts", '["host-a"]'),
+            ("targets", '["target-b", "target-a"]'),
+            ("host_components", '["rustc", "cargo", "rustfmt"]'),
+        ):
+            original = path.read_text(encoding="utf-8")
+            lines = [
+                f"{field} = {replacement}" if line.startswith(f"{field} = ") else line
+                for line in original.splitlines()
+            ]
+            path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+            try:
+                validate(path, hosts, targets, components)
+            except ValueError:
+                pass
+            else:
+                raise AssertionError(f"mismatched {field} declaration was accepted")
+            path.write_text(original, encoding="utf-8")
+
+
+def main() -> None:
+    if sys.argv[1:] == ["--self-test"]:
+        self_test()
+        return
+    if len(sys.argv) != 5:
+        raise SystemExit(
+            "usage: script/validate-rust-lock-surface <lockfile> <hosts-csv> <targets-csv> <components-csv>"
+        )
+    validate(
+        pathlib.Path(sys.argv[1]),
+        parse_csv(sys.argv[2]),
+        parse_csv(sys.argv[3]),
+        parse_csv(sys.argv[4]),
+    )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (OSError, ValueError, tomllib.TOMLDecodeError, AssertionError) as error:
+        raise SystemExit(str(error)) from None

--- a/script/validate-rust-toolchain
+++ b/script/validate-rust-toolchain
@@ -23,6 +23,17 @@ if [[ ! -f "$rust_lockfile" ]]; then
   die "missing Rust toolchain lockfile: $rust_lockfile"
 fi
 
+require_cmd python3
+hosts_csv="$(rust_dist_csv "${RUST_DIST_HOSTS[@]}")"
+targets_csv="$(rust_dist_csv "${RUST_DIST_TARGETS[@]}")"
+host_components_csv="$(rust_dist_csv "${RUST_DIST_HOST_COMPONENTS[@]}")"
+python3 -B -E "$DIR/script/validate-rust-lock-surface" \
+  "$rust_lockfile" \
+  "$hosts_csv" \
+  "$targets_csv" \
+  "$host_components_csv"
+python3 -B -E "$DIR/script/validate-rust-lock-surface" --self-test
+
 require_cmd_for_online() {
   require_cmd curl
   require_cmd python3
@@ -123,8 +134,6 @@ if [[ "$online" == "true" ]]; then
     die "Rust channel manifest checksum mismatch against ${RUST_TOOLCHAIN_LOCK#$DIR/}"
   fi
 
-  hosts_csv="$(rust_dist_csv "${RUST_DIST_HOSTS[@]}")"
-  targets_csv="$(rust_dist_csv "${RUST_DIST_TARGETS[@]}")"
   if ! diff -u <(rust_dist_artifact_entries "$rust_lockfile" | sort) <(rust_dist_generate_artifact_entries_from_manifest "$manifest_file" "$expected_version" "$hosts_csv" "$targets_csv" | sort); then
     die "Rust artifact locks differ from upstream channel manifest"
   fi


### PR DESCRIPTION
## Summary

Validate the Rust toolchain lock's declared host, target, and host-component surface instead of relying only on the artifact records and hard-coded installer arrays.

## Problem

`.cargo/tooling/rust-toolchain.lock.toml` explicitly records three reviewed declarations under `[rust]`: `hosts`, `targets`, and `host_components`. `script/vendor-rust` generates those fields from the same authoritative arrays used by the installer.

On the base commit, `script/validate-rust-toolchain` never reads those declarations. It correctly requires the individual 24 artifact records and, online, compares those records with the upstream Rust channel manifest, but the lock's own advertised surface can disagree with the records that are actually validated.

That leaves a self-contradictory source-of-truth file: current code may behave safely because it ignores the declarations, while a reviewer or future consumer can reasonably interpret the recorded arrays as the lock's supported toolchain surface.

## Evidence / reproduction

- `script/lib/rust-dist.bash` defines the reviewed `RUST_DIST_HOSTS`, `RUST_DIST_TARGETS`, and `RUST_DIST_HOST_COMPONENTS` arrays.
- `rust_dist_write_lockfile` serializes those arrays into `[rust]` as `hosts`, `targets`, and `host_components`.
- The committed Rust lock contains all three declarations.
- `script/validate-rust-toolchain` uses the shell arrays to require each host/component and target artifact, and requires 24 artifact records, but on the base commit it does not parse or compare the three declared arrays.
- Minimal reproduction: change only `hosts = [...]` in the committed lock to a shorter or reordered list while leaving all 24 artifact records, version, manifest URL, and checksums untouched. The base validator continues validating the artifact records and does not reject the contradictory declaration.
- The new self-test covers mismatched host, target, and component declarations independently.

## Change

- parse the Rust lock with Python's standard-library TOML parser
- require its declared `hosts`, `targets`, and `host_components` arrays to exactly match the existing authoritative Rust distribution arrays
- pass those same arrays into the validator rather than duplicating platform values
- run a focused declaration self-test from the normal Rust lock validation path
- reuse the already-derived host/target CSV values for the online upstream-manifest comparison

No Rust version, artifact URL, checksum, supported platform, or installation behavior changes.